### PR TITLE
[device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py]

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -6,7 +6,7 @@
 try:
     import time
     import subprocess
-    from sonic_sfp.sfputilbase import SfpUtilBase
+    from sonic_sfp.sfputilbase import *
 except ImportError as e:
     raise ImportError("%s - required module not found" % str(e))
 
@@ -191,3 +191,362 @@ class SfpUtil(SfpUtilBase):
 
         return status, phy_port_dict
 
+    def _read_eeprom_specific_bytes(self, sysfsfile_eeprom, offset, num_bytes):
+        print("_read_eeprom_specific_bytes should not be called since the sysfs it dependents on will no longer exist.")
+        print("_read_eeprom_specific_bytes_via_ethtool should be called instead")
+        raise Exception()
+
+    # Read out any bytes from any offset
+    def _read_eeprom_specific_bytes_via_ethtool(self, port_num, offset, num_bytes):
+
+        port_num += 1
+        sfpname = "sfp" + str(port_num)
+
+        eeprom_raw = []
+        ethtool_cmd = "ethtool -m {} hex on offset {} length {}".format(sfpname, offset, num_bytes)
+        try:
+            output = subprocess.check_output(ethtool_cmd, shell=True)
+            output_lines = output.splitlines()
+            first_line_raw = output_lines[0]
+            if "Offset" in first_line_raw:
+                for line in output_lines[2:]:
+                    line_split = line.split()
+                    eeprom_raw = eeprom_raw + line_split[1:]
+        except subprocess.CalledProcessError as e:
+            return None
+
+        return eeprom_raw
+
+    # Read eeprom
+    def _read_eeprom_devid(self, port_num, devid, offset, num_bytes = 512):
+
+        if port_num in self.osfp_ports:
+            pass
+        elif port_num in self.qsfp_ports:
+            pass
+        elif (self.DOM_EEPROM_ADDR == devid):
+                offset += 256
+
+        eeprom_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, offset, num_bytes)
+
+        return eeprom_raw
+
+    # Read out SFP type, vendor name, PN, REV, SN from eeprom.
+    def get_transceiver_info_dict(self, port_num):
+        transceiver_info_dict = {}
+        compliance_code_dict = {}
+
+        # ToDo: OSFP tranceiver info parsing not fully supported.
+        # in inf8628.py lack of some memory map definition
+        # will be implemented when the inf8628 memory map ready
+        if port_num in self.osfp_ports:
+            offset = 0
+            vendor_rev_width = XCVR_HW_REV_WIDTH_OSFP
+
+            sfpi_obj = inf8628InterfaceId()
+            if sfpi_obj is None:
+                print("Error: sfp_object open failed")
+                return None
+
+            sfp_type_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + OSFP_TYPE_OFFSET), XCVR_TYPE_WIDTH)
+            if sfp_type_raw is not None:
+                sfp_type_data = sfpi_obj.parse_sfp_type(sfp_type_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_name_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + OSFP_VENDOR_NAME_OFFSET), XCVR_VENDOR_NAME_WIDTH)
+            if sfp_vendor_name_raw is not None:
+                sfp_vendor_name_data = sfpi_obj.parse_vendor_name(sfp_vendor_name_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_pn_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + OSFP_VENDOR_PN_OFFSET), XCVR_VENDOR_PN_WIDTH)
+            if sfp_vendor_pn_raw is not None:
+                sfp_vendor_pn_data = sfpi_obj.parse_vendor_pn(sfp_vendor_pn_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_rev_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + OSFP_HW_REV_OFFSET), vendor_rev_width)
+            if sfp_vendor_rev_raw is not None:
+                sfp_vendor_rev_data = sfpi_obj.parse_vendor_rev(sfp_vendor_rev_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_sn_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + OSFP_VENDOR_SN_OFFSET), XCVR_VENDOR_SN_WIDTH)
+            if sfp_vendor_sn_raw is not None:
+                sfp_vendor_sn_data = sfpi_obj.parse_vendor_sn(sfp_vendor_sn_raw, 0)
+            else:
+                return None
+
+            try:
+                sysfsfile_eeprom.close()
+            except IOError:
+                print("Error: closing sysfs file %s" % file_path)
+                return None
+
+            transceiver_info_dict['type'] = sfp_type_data['data']['type']['value']
+            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            # Below part is added to avoid fail the xcvrd, shall be implemented later
+            transceiver_info_dict['vendor_oui'] = 'N/A'
+            transceiver_info_dict['vendor_date'] = 'N/A'
+            transceiver_info_dict['Connector'] = 'N/A'
+            transceiver_info_dict['encoding'] = 'N/A'
+            transceiver_info_dict['ext_identifier'] = 'N/A'
+            transceiver_info_dict['ext_rateselect_compliance'] = 'N/A'
+            transceiver_info_dict['cable_type'] = 'N/A'
+            transceiver_info_dict['cable_length'] = 'N/A'
+            transceiver_info_dict['specification_compliance'] = 'N/A'
+            transceiver_info_dict['nominal_bit_rate'] = 'N/A'
+
+        else:
+            if port_num in self.qsfp_ports:
+                offset = 128
+                vendor_rev_width = XCVR_HW_REV_WIDTH_QSFP
+                cable_length_width = XCVR_CABLE_LENGTH_WIDTH_QSFP
+                interface_info_bulk_width = XCVR_INTFACE_BULK_WIDTH_QSFP
+                sfp_type = 'QSFP'
+
+                sfpi_obj = sff8436InterfaceId()
+                if sfpi_obj is None:
+                    print("Error: sfp_object open failed")
+                    return None
+
+            else:
+                offset = 0
+                vendor_rev_width = XCVR_HW_REV_WIDTH_SFP
+                cable_length_width = XCVR_CABLE_LENGTH_WIDTH_SFP
+                interface_info_bulk_width = XCVR_INTFACE_BULK_WIDTH_SFP
+                sfp_type = 'SFP'
+
+                sfpi_obj = sff8472InterfaceId()
+                if sfpi_obj is None:
+                    print("Error: sfp_object open failed")
+                    return None
+
+            sfp_interface_bulk_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_INTFACE_BULK_OFFSET), interface_info_bulk_width)
+            if sfp_interface_bulk_raw is not None:
+                sfp_interface_bulk_data = sfpi_obj.parse_sfp_info_bulk(sfp_interface_bulk_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_name_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_VENDOR_NAME_OFFSET), XCVR_VENDOR_NAME_WIDTH)
+            if sfp_vendor_name_raw is not None:
+                sfp_vendor_name_data = sfpi_obj.parse_vendor_name(sfp_vendor_name_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_pn_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_VENDOR_PN_OFFSET), XCVR_VENDOR_PN_WIDTH)
+            if sfp_vendor_pn_raw is not None:
+                sfp_vendor_pn_data = sfpi_obj.parse_vendor_pn(sfp_vendor_pn_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_rev_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_HW_REV_OFFSET), vendor_rev_width)
+            if sfp_vendor_rev_raw is not None:
+                sfp_vendor_rev_data = sfpi_obj.parse_vendor_rev(sfp_vendor_rev_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_sn_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_VENDOR_SN_OFFSET), XCVR_VENDOR_SN_WIDTH)
+            if sfp_vendor_sn_raw is not None:
+                sfp_vendor_sn_data = sfpi_obj.parse_vendor_sn(sfp_vendor_sn_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_oui_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_VENDOR_OUI_OFFSET), XCVR_VENDOR_OUI_WIDTH)
+            if sfp_vendor_oui_raw is not None:
+                sfp_vendor_oui_data = sfpi_obj.parse_vendor_oui(sfp_vendor_oui_raw, 0)
+            else:
+                return None
+
+            sfp_vendor_date_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + XCVR_VENDOR_DATE_OFFSET), XCVR_VENDOR_DATE_WIDTH)
+            if sfp_vendor_date_raw is not None:
+                sfp_vendor_date_data = sfpi_obj.parse_vendor_date(sfp_vendor_date_raw, 0)
+            else:
+                return None
+
+            transceiver_info_dict['type'] = sfp_interface_bulk_data['data']['type']['value']
+            transceiver_info_dict['manufacturename'] = sfp_vendor_name_data['data']['Vendor Name']['value']
+            transceiver_info_dict['modelname'] = sfp_vendor_pn_data['data']['Vendor PN']['value']
+            transceiver_info_dict['hardwarerev'] = sfp_vendor_rev_data['data']['Vendor Rev']['value']
+            transceiver_info_dict['serialnum'] = sfp_vendor_sn_data['data']['Vendor SN']['value']
+            transceiver_info_dict['vendor_oui'] = sfp_vendor_oui_data['data']['Vendor OUI']['value']
+            transceiver_info_dict['vendor_date'] = sfp_vendor_date_data['data']['VendorDataCode(YYYY-MM-DD Lot)']['value']
+            transceiver_info_dict['Connector'] = sfp_interface_bulk_data['data']['Connector']['value']
+            transceiver_info_dict['encoding'] = sfp_interface_bulk_data['data']['EncodingCodes']['value']
+            transceiver_info_dict['ext_identifier'] = sfp_interface_bulk_data['data']['Extended Identifier']['value']
+            transceiver_info_dict['ext_rateselect_compliance'] = sfp_interface_bulk_data['data']['RateIdentifier']['value']
+            if sfp_type == 'QSFP':
+                for key in qsfp_cable_length_tup:
+                    if key in sfp_interface_bulk_data['data']:
+                        transceiver_info_dict['cable_type'] = key
+                        transceiver_info_dict['cable_length'] = str(sfp_interface_bulk_data['data'][key]['value'])
+
+                for key in qsfp_compliance_code_tup:
+                    if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
+                        compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
+                transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
+                
+                transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['Nominal Bit Rate(100Mbs)']['value'])
+            else:
+                for key in sfp_cable_length_tup:
+                    if key in sfp_interface_bulk_data['data']:
+                        transceiver_info_dict['cable_type'] = key
+                        transceiver_info_dict['cable_length'] = str(sfp_interface_bulk_data['data'][key]['value'])
+
+                for key in sfp_compliance_code_tup:
+                    if key in sfp_interface_bulk_data['data']['Specification compliance']['value']:
+                        compliance_code_dict[key] = sfp_interface_bulk_data['data']['Specification compliance']['value'][key]['value']
+                transceiver_info_dict['specification_compliance'] = str(compliance_code_dict)
+
+                transceiver_info_dict['nominal_bit_rate'] = str(sfp_interface_bulk_data['data']['NominalSignallingRate(UnitsOf100Mbd)']['value'])
+
+        return transceiver_info_dict
+
+    def get_transceiver_dom_info_dict(self, port_num, batchread=False, test=False):
+
+        transceiver_dom_info_dict = {}
+
+        if port_num in self.osfp_ports:
+
+            # Below part is added to avoid fail xcvrd, shall be implemented later
+            transceiver_dom_info_dict['temperature'] = 'N/A'
+            transceiver_dom_info_dict['voltage'] = 'N/A'
+            transceiver_dom_info_dict['rx1power'] = 'N/A'
+            transceiver_dom_info_dict['rx2power'] = 'N/A'
+            transceiver_dom_info_dict['rx3power'] = 'N/A'
+            transceiver_dom_info_dict['rx4power'] = 'N/A'
+            transceiver_dom_info_dict['tx1bias'] = 'N/A'
+            transceiver_dom_info_dict['tx2bias'] = 'N/A'
+            transceiver_dom_info_dict['tx3bias'] = 'N/A'
+            transceiver_dom_info_dict['tx4bias'] = 'N/A'
+            transceiver_dom_info_dict['tx1power'] = 'N/A'
+            transceiver_dom_info_dict['tx2power'] = 'N/A'
+            transceiver_dom_info_dict['tx3power'] = 'N/A'
+            transceiver_dom_info_dict['tx4power'] = 'N/A'
+
+        elif port_num in self.qsfp_ports:
+            offset = 0
+            offset_xcvr = 128
+
+            sfpd_obj = sff8436Dom()
+            if sfpd_obj is None:
+                return None
+
+            sfpi_obj = sff8436InterfaceId()
+            if sfpi_obj is None:
+                return None
+
+            # QSFP capability byte parse, through this byte can know whether it support tx_power or not.
+            # TODO: in the future when decided to migrate to support SFF-8636 instead of SFF-8436,
+            # need to add more code for determining the capability and version compliance
+            # in SFF-8636 dom capability definitions evolving with the versions.
+            qsfp_dom_capability_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset_xcvr + XCVR_DOM_CAPABILITY_OFFSET), XCVR_DOM_CAPABILITY_WIDTH)
+            if qsfp_dom_capability_raw is not None:
+                qspf_dom_capability_data = sfpi_obj.parse_qsfp_dom_capability(qsfp_dom_capability_raw, 0)
+            else:
+                return None
+
+            dom_temperature_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_TEMPE_OFFSET), QSFP_TEMPE_WIDTH)
+            if dom_temperature_raw is not None:
+                dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+            else:
+                return None
+
+            dom_voltage_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_VLOT_OFFSET), QSFP_VOLT_WIDTH)
+            if dom_voltage_raw is not None:
+                dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+            else:
+                return None
+
+            qsfp_dom_rev_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_DOM_REV_OFFSET), QSFP_DOM_REV_WIDTH)
+            if qsfp_dom_rev_raw is not None:
+                qsfp_dom_rev_data = sfpd_obj.parse_sfp_dom_rev(qsfp_dom_rev_raw, 0)
+            else:
+                return None
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+
+            # The tx_power monitoring is only available on QSFP which compliant with SFF-8636
+            # and claimed that it support tx_power with one indicator bit.
+            dom_channel_monitor_data = {}
+            qsfp_dom_rev = qsfp_dom_rev_data['data']['dom_rev']['value']
+            qsfp_tx_power_support = qspf_dom_capability_data['data']['Tx_power_support']['value']
+            if (qsfp_dom_rev[0:8] != 'SFF-8636' or (qsfp_dom_rev[0:8] == 'SFF-8636' and qsfp_tx_power_support != 'on')):
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+                else:
+                    return None
+
+                transceiver_dom_info_dict['tx1power'] = 'N/A'
+                transceiver_dom_info_dict['tx2power'] = 'N/A'
+                transceiver_dom_info_dict['tx3power'] = 'N/A'
+                transceiver_dom_info_dict['tx4power'] = 'N/A'
+            else:
+                dom_channel_monitor_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num, (offset + QSFP_CHANNL_MON_OFFSET), QSFP_CHANNL_MON_WITH_TX_POWER_WIDTH)
+                if dom_channel_monitor_raw is not None:
+                    dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params_with_tx_power(dom_channel_monitor_raw, 0)
+                else:
+                    return None
+
+                transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TX1Power']['value']
+                transceiver_dom_info_dict['tx2power'] = dom_channel_monitor_data['data']['TX2Power']['value']
+                transceiver_dom_info_dict['tx3power'] = dom_channel_monitor_data['data']['TX3Power']['value']
+                transceiver_dom_info_dict['tx4power'] = dom_channel_monitor_data['data']['TX4Power']['value']
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+            transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RX1Power']['value']
+            transceiver_dom_info_dict['rx2power'] = dom_channel_monitor_data['data']['RX2Power']['value']
+            transceiver_dom_info_dict['rx3power'] = dom_channel_monitor_data['data']['RX3Power']['value']
+            transceiver_dom_info_dict['rx4power'] = dom_channel_monitor_data['data']['RX4Power']['value']
+            transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TX1Bias']['value']
+            transceiver_dom_info_dict['tx2bias'] = dom_channel_monitor_data['data']['TX2Bias']['value']
+            transceiver_dom_info_dict['tx3bias'] = dom_channel_monitor_data['data']['TX3Bias']['value']
+            transceiver_dom_info_dict['tx4bias'] = dom_channel_monitor_data['data']['TX4Bias']['value']
+
+        else:
+            offset = 256
+
+            eeprom_raw = ['0'] * 256
+            eeprom_raw[92:92+16] = self._read_eeprom_specific_bytes_via_ethtool(port_num, 92, 16)
+            sfp_obj = sff8472InterfaceId()
+            calibration_type = sfp_obj._get_calibration_type(eeprom_raw)
+
+            eeprom_domraw = self._read_eeprom_specific_bytes_via_ethtool(port_num, offset, 256)
+
+            sfpd_obj = sff8472Dom(None, calibration_type)
+            if sfpd_obj is None:
+                print "no sff8472Dom"
+                return None
+
+            dom_temperature_raw = eeprom_domraw[SFP_TEMPE_OFFSET:SFP_TEMPE_OFFSET+SFP_TEMPE_WIDTH]
+            dom_temperature_data = sfpd_obj.parse_temperature(dom_temperature_raw, 0)
+
+            dom_voltage_raw = eeprom_domraw[SFP_VLOT_OFFSET:SFP_VLOT_OFFSET+SFP_VOLT_WIDTH]
+            dom_voltage_data = sfpd_obj.parse_voltage(dom_voltage_raw, 0)
+
+            dom_channel_monitor_raw = eeprom_domraw[SFP_CHANNL_MON_OFFSET:SFP_CHANNL_MON_OFFSET+SFP_CHANNL_MON_WIDTH]
+            dom_channel_monitor_data = sfpd_obj.parse_channel_monitor_params(dom_channel_monitor_raw, 0)
+
+            transceiver_dom_info_dict['temperature'] = dom_temperature_data['data']['Temperature']['value']
+            transceiver_dom_info_dict['voltage'] = dom_voltage_data['data']['Vcc']['value']
+            transceiver_dom_info_dict['rx1power'] = dom_channel_monitor_data['data']['RXPower']['value']
+            transceiver_dom_info_dict['rx2power'] = 'N/A'
+            transceiver_dom_info_dict['rx3power'] = 'N/A'
+            transceiver_dom_info_dict['rx4power'] = 'N/A'
+            transceiver_dom_info_dict['tx1bias'] = dom_channel_monitor_data['data']['TXBias']['value']
+            transceiver_dom_info_dict['tx2bias'] = 'N/A'
+            transceiver_dom_info_dict['tx3bias'] = 'N/A'
+            transceiver_dom_info_dict['tx4bias'] = 'N/A'
+            transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TXPower']['value']
+            transceiver_dom_info_dict['tx2power'] = 'N/A'
+            transceiver_dom_info_dict['tx3power'] = 'N/A'
+            transceiver_dom_info_dict['tx4power'] = 'N/A'
+
+        return transceiver_dom_info_dict


### PR DESCRIPTION
**- What I did**
purpose and restrictions
1. reading eeprom via ethtool.
2. avoid changing common codes shared by all the manufacture (sonic-platform-common), limit all the modifications with Mellanox-specific code.

**- How I did it**
current implementation
A new class based on SfpUtilBase and a new method _read_eeprom_specific_bytes_via_ethtool have been introduced in order to change the way the eeprom DOM data is read. Typically the best practice to do this kind of thing is to limit the modification within the function which executes reading operations only and keep other stuff (especially the interface) untouched. However, this can hardly be achieved since the original reading function takes the file object as input parameter to represent the port. It is done by having the file object to point to /var/run/hwmanagement files, which will not be maintained in the future. As a result, a new interface has to be introduced with a port number/name as input parameter in order to get rid of the dependency on those files:
_read_eeprom_specific_bytes_via_ethtool
Since the interface changed, all methods that call the interface should also be overwritten in order to call the new interface, including:
_read_eeprom_devid
get_transceiver_info_dict
get_transceiver_dom_info_dict
Only interface used to read eeprom DOM has been replaced and the main logic has not been changed except the following mentioned.
1. reading DOM data for sfp port, which is implementioned in get_transceiver_dom_info_dict. In this case a "calibration" should be firstly read from eeprom before other values like temperature, voltage, rx/tx power, can be parsed. However, this has been ignored in the original code, resulting in that the data can't be parsed.
2. In the original implemention, the data area containing the data is read from DOM separately in order to avoid read unnecessary data and achieve better performance. Having used ethtool to read DOM data, the performance gap between reading all the area and reading the spot data separately has been narrowed to almost zero. To make the code neat and readable, we change the way to read this data.
