### PR TITLE
[sfputil]Remove the dependency on sysfs for sfputil

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -37,15 +37,12 @@ class SfpUtil(SfpUtilBase):
     PORTS_IN_BLOCK = 0
     EEPROM_OFFSET = 0
 
-    _port_to_eeprom_mapping = {}
-
     db_sel = None
     db_sel_timeout = None
     db_sel_object = None
     db_sel_tbl = None
     state_db = None
     sfpd_status_tbl = None
-    qsfp_sysfs_path = "/var/run/hw-management/qsfp/"
 
     @property
     def port_start(self):
@@ -61,7 +58,8 @@ class SfpUtil(SfpUtilBase):
 
     @property
     def port_to_eeprom_mapping(self):
-        return self._port_to_eeprom_mapping
+        print "dependency on sysfs has been removed"
+        raise Exception() 
 
     def get_port_position_tuple_by_sku_name(self):
         p = subprocess.Popen(GET_HWSKU_CMD, shell=True, stdout=subprocess.PIPE)
@@ -77,9 +75,6 @@ class SfpUtil(SfpUtilBase):
         self.PORTS_IN_BLOCK = port_position_tuple[3]
         self.EEPROM_OFFSET = port_position_tuple[4]
 
-        for x in range(0, self.port_end + 1):
-            self._port_to_eeprom_mapping[x] = self.qsfp_sysfs_path + "qsfp{}".format(x + self.EEPROM_OFFSET)
-
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
@@ -87,19 +82,23 @@ class SfpUtil(SfpUtilBase):
         if port_num < self.port_start or port_num > self.port_end:
             return False
 
+        port_num += SFP_PORT_NAME_OFFSET
+        sfpname = SFP_PORT_NAME_CONVENTION.format(port_num)
+        presence = False
+
+        ethtool_cmd = "ethtool -m {} 2>/dev/null".format(sfpname)
         try:
-            reg_file = open(self.qsfp_sysfs_path + "qsfp{}_status".format(port_num + 1))
-        except IOError as e:
-            print "Error: unable to open file: %s" % str(e)
-            return False
+            proc = subprocess.Popen(ethtool_cmd, stdout=subprocess.PIPE, shell=True, stderr=subprocess.STDOUT)
+            stdout = proc.communicate()[0]
+            proc.wait()
+            result = stdout.rstrip('\n')
+            if result != '':
+                presence = True
 
-        content = reg_file.readline().rstrip()
+        except OSError, e:
+            return presence
 
-        # content is a string with the qsfp status
-        if content == SFP_STATUS_INSERTED:
-            return True
-
-        return False
+        return presence
 
     def get_low_power_mode(self, port_num):
         # Check for invalid port_num
@@ -405,7 +404,7 @@ class SfpUtil(SfpUtilBase):
     def get_transceiver_dom_info_dict(self, port_num):
         transceiver_dom_info_dict = {}
 
-        # Below part is added to avoid fail xcvrd
+        # Below part is added to avoid failing xcvrd
         # Currently, the way in which dom data is read has been changed from
         # using sysfs to using ethtool.
         # The ethtool returns None for ports without dom support, resulting in 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -78,13 +78,14 @@ class SfpUtil(SfpUtilBase):
         SfpUtilBase.__init__(self)
 
     def get_presence(self, port_num):
+        presence = False
+
         # Check for invalid port_num
         if port_num < self.port_start or port_num > self.port_end:
-            return False
+            return presence
 
         port_num += SFP_PORT_NAME_OFFSET
         sfpname = SFP_PORT_NAME_CONVENTION.format(port_num)
-        presence = False
 
         ethtool_cmd = "ethtool -m {} 2>/dev/null".format(sfpname)
         try:


### PR DESCRIPTION
**- What I did**
Remove the dependency on sysfs for sfputil, mainly get_presence and port_to_eeprom_mapping

**- How I did it**
in sfputil:
1. rewrite get_presence by using ethtool;
2. remove interface port_to_eeprom_mapping which is no longer referenced;
3. remove code that references port_to_eeprom_mapping and _port_to_eeprom_mapping;
4. remove private member qsfp_sysfs_path which is no longer referenced.

**- How to verify it**
check the output of the following commands
sudo sfputil show -p Ethernetxxx
sudo sfputil show -d -p Ethernetxxx
reload config and then check whether STATE_DB contains correct data for TRANSCEIVER_DOM_SENSOR and TRANSCEIVER_INFO

**- Description for the changelog**
Remove the dependency on sysfs for sfputil

**- A picture of a cute animal (not mandatory but encouraged)**
