### PR TITLE
[Mellanox]Fix issue: xcvrd broken due to an unsupported interface called

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -556,3 +556,21 @@ class SfpUtil(SfpUtilBase):
             transceiver_dom_info_dict['tx1power'] = dom_channel_monitor_data['data']['TXPower']['value']
 
         return transceiver_dom_info_dict
+
+    def get_transceiver_dom_threshold_info_dict(self, port_num):
+        transceiver_dom_threshold_info_dict = {}
+
+        dom_info_dict_keys = ['temphighalarm',    'temphighwarning',
+                              'templowalarm',     'templowwarning',
+                              'vcchighalarm',     'vcchighwarning',
+                              'vcclowalarm',      'vcclowwarning',
+                              'rxpowerhighalarm', 'rxpowerhighwarning',
+                              'rxpowerlowalarm',  'rxpowerlowwarning',
+                              'txpowerhighalarm', 'txpowerhighwarning',
+                              'txpowerlowalarm',  'txpowerlowwarning',
+                              'txbiashighalarm',  'txbiashighwarning',
+                              'txbiaslowalarm',   'txbiaslowwarning'
+                             ]
+        transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
+
+        return transceiver_dom_threshold_info_dict

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -12,6 +12,11 @@ except ImportError as e:
 
 # sfp supports dom
 XCVR_DOM_CAPABILITY_DOM_SUPPORT_BIT = 0x40
+
+# sfp module threshold offset and width
+SFP_MODULE_THRESHOLD_OFFSET = 0
+SFP_MODULE_THRESHOLD_WIDTH = 56
+
 # I2C page size for sfp
 SFP_I2C_PAGE_SIZE = 256
 
@@ -578,8 +583,6 @@ class SfpUtil(SfpUtilBase):
             return transceiver_dom_threshold_info_dict
         else:
             offset = 256
-            SFP_MODULE_THRESHOLD_OFFSET = 0
-            SFP_MODULE_THRESHOLD_WIDTH = 56
 
             eeprom_raw = ['0'] * SFP_I2C_PAGE_SIZE
             eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET : XCVR_DOM_CAPABILITY_OFFSET + XCVR_DOM_CAPABILITY_WIDTH] = \

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/sfputil.py
@@ -573,4 +573,56 @@ class SfpUtil(SfpUtilBase):
                              ]
         transceiver_dom_threshold_info_dict = dict.fromkeys(dom_info_dict_keys, 'N/A')
 
+        if port_num in self.qsfp_ports:
+            # current we don't support qsfp since threshold data is on page 3 and the way to read this page is under discussion.
+            return transceiver_dom_threshold_info_dict
+        else:
+            offset = 256
+            SFP_MODULE_THRESHOLD_OFFSET = 0
+            SFP_MODULE_THRESHOLD_WIDTH = 56
+
+            eeprom_raw = ['0'] * SFP_I2C_PAGE_SIZE
+            eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET : XCVR_DOM_CAPABILITY_OFFSET + XCVR_DOM_CAPABILITY_WIDTH] = \
+                self._read_eeprom_specific_bytes_via_ethtool(port_num, XCVR_DOM_CAPABILITY_OFFSET, XCVR_DOM_CAPABILITY_WIDTH)
+            sfp_obj = sff8472InterfaceId()
+            calibration_type = sfp_obj._get_calibration_type(eeprom_raw)
+
+            dom_supported = (int(eeprom_raw[XCVR_DOM_CAPABILITY_OFFSET], 16) & XCVR_DOM_CAPABILITY_DOM_SUPPORT_BIT != 0)
+            if not dom_supported:
+                return transceiver_dom_threshold_info_dict
+
+            sfpd_obj = sff8472Dom(None, calibration_type)
+            if sfpd_obj is None:
+                return transceiver_dom_threshold_info_dict
+
+            dom_module_threshold_raw = self._read_eeprom_specific_bytes_via_ethtool(port_num,
+                                         (offset + SFP_MODULE_THRESHOLD_OFFSET),
+                                         SFP_MODULE_THRESHOLD_WIDTH)
+            if dom_module_threshold_raw is not None:
+                dom_module_threshold_data = sfpd_obj.parse_alarm_warning_threshold(dom_module_threshold_raw, 0)
+            else:
+                return transceiver_dom_threshold_info_dict
+
+            # Threshold Data
+            transceiver_dom_threshold_info_dict['temphighalarm'] = dom_module_threshold_data['data']['TempHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['templowalarm'] = dom_module_threshold_data['data']['TempLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['temphighwarning'] = dom_module_threshold_data['data']['TempHighWarning']['value']
+            transceiver_dom_threshold_info_dict['templowwarning'] = dom_module_threshold_data['data']['TempLowWarning']['value']
+            transceiver_dom_threshold_info_dict['vcchighalarm'] = dom_module_threshold_data['data']['VoltageHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcclowalarm'] = dom_module_threshold_data['data']['VoltageLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['vcchighwarning'] = dom_module_threshold_data['data']['VoltageHighWarning']['value']
+            transceiver_dom_threshold_info_dict['vcclowwarning'] = dom_module_threshold_data['data']['VoltageLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiashighalarm'] = dom_module_threshold_data['data']['BiasHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowalarm'] = dom_module_threshold_data['data']['BiasLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txbiashighwarning'] = dom_module_threshold_data['data']['BiasHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txbiaslowwarning'] = dom_module_threshold_data['data']['BiasLowWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighalarm'] = dom_module_threshold_data['data']['TXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowalarm'] = dom_module_threshold_data['data']['TXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['txpowerhighwarning'] = dom_module_threshold_data['data']['TXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['txpowerlowwarning'] = dom_module_threshold_data['data']['TXPowerLowWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighalarm'] = dom_module_threshold_data['data']['RXPowerHighAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowalarm'] = dom_module_threshold_data['data']['RXPowerLowAlarm']['value']
+            transceiver_dom_threshold_info_dict['rxpowerhighwarning'] = dom_module_threshold_data['data']['RXPowerHighWarning']['value']
+            transceiver_dom_threshold_info_dict['rxpowerlowwarning'] = dom_module_threshold_data['data']['RXPowerLowWarning']['value']
+
         return transceiver_dom_threshold_info_dict


### PR DESCRIPTION
**- What I did**
Fix issue: xcvrd is broken due to a newly introduced interface get_transceiver_dom_threshold_info_dict calling the unsupported interface _read_eeprom_specific_bytes.

**- How I did it**
implement get_transceiver_dom_threshold_info_dict as returning all field filled with "N/A"

**- How to verify it**
run xcvrd with the latest version of sonic-platform-common and sonic-platform-daemons

**- Description for the changelog**
[Mellanox]Fix issue: xcvrd broken due to an unsupported interface called

**- A picture of a cute animal (not mandatory but encouraged)**
