### PR TITLE
[syncd.sh,pmon.service] Prevent pmon from starting ahead of syncd

### DIFF
--- a/files/build_templates/pmon.service.j2
+++ b/files/build_templates/pmon.service.j2
@@ -2,6 +2,9 @@
 Description=Platform monitor container
 Requires=updategraph.service
 After=updategraph.service
+{% if sonic_asic_platform == 'mellanox' %}
+After=syncd.service
+{% endif %}
 Before=ntp-config.service
 
 [Service]

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -109,10 +109,6 @@ start() {
             /usr/bin/hw-management.sh chipdown
         fi
 
-        debug "Starting pmon service..."
-        /bin/systemctl start pmon
-        debug "Started pmon service"
-
         if [[ x"$BOOT_TYPE" == x"fast" ]]; then
             /usr/bin/hw-management.sh chipupdis
         fi
@@ -136,6 +132,11 @@ start() {
 }
 
 wait() {
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
+    fi
     /usr/bin/${SERVICE}.sh wait
 }
 


### PR DESCRIPTION

**- What I did**
Prevent pmon from starting ahead of syncd by adding syncd.service as "After" of pmon.service.
This PR is one of the options that solve the comments of [[syncd.sh] stop pmon ahead of syncd in flows except warm reboot #7](https://github.com/stephenxs/sonic-buildimage/pull/7)

**- How I did it**
During system starting, pmon isn't supposed to start ahead of syncd starting in order to avoid racing condition between syncd and pmon.
Currently it is done by killing pmon if is alive when syncd is starting. However such implementation is still risky. Consider the following flow:
1. pmon is inactive when syncd.sh is checking. but syncd.sh is scheduled out somehow just ahead of "chipdown" called
2. systemd is switched in and starts pmon service
3. at this point, pmon and syncd are running simultaneously, critical section broken and racing condition formed

To prevent that issue, ony solution is to add syncd as "After" in pmon.service, which ensure that whenever pmon starts syncd has been started.
However, dong so requires to defer starting pmon.service after syncd.service has fully started otherwise a deadlock is formed as following:
1. syncd.sh starts pmon ahead of itself fully started, while
2. pmon not being able to start due to syncd, one of its "After", not fully started.
3. as a result, syncd and pmon have to wait for each other forever

To solve that, move starting pmon.service to "wait()" so that pmon is started after syncd fully started, breaking the deadlock.


**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
