### PR TITLE
[Mellanox] Fix typo in get_change_event

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -523,4 +523,4 @@ class Chassis(ChassisBase):
                 i = i + 1
             return True, {'sfp':port_dict}
         else:
-            return True, {}
+            return True, {'sfp':{}}


### PR DESCRIPTION
**- What I did**
Fix issue in get_change_event: the returned dictionary doesn't contain 'sfp' key. Sometimes it can fail xcvrd.

**- How I did it**
Add the 'sfp' key.

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
