### PR TITLE
[Mellanox]Correct reboot cause when reboot via power cycle

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -320,7 +320,6 @@ class Chassis(ChassisBase):
             'reset_comex_wd'            :   "Reset requested from ComEx",
             'reset_from_asic'           :   "Reset requested from ASIC",
             'reset_reload_bios'         :   "Reset caused by BIOS reload",
-            'reset_sw_reset'            :   "Software reset",
             'reset_hotswap_or_halt'     :   "Reset caused by hotswap or halt",
             'reset_from_comex'          :   "Reset from ComEx",
             'reset_voltmon_upgrade_fail':   "Reset due to voltage monitor devices upgrade failure"

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -324,6 +324,7 @@ class Chassis(ChassisBase):
             'reset_from_comex'          :   "Reset from ComEx",
             'reset_voltmon_upgrade_fail':   "Reset due to voltage monitor devices upgrade failure"
         }
+        self.reboot_by_software = 'reset_sw_reset'
         self.reboot_cause_initialized = True
 
 
@@ -349,6 +350,11 @@ class Chassis(ChassisBase):
         for reset_file, reset_cause in self.reboot_minor_cause_dict.iteritems():
             if self._verify_reboot_cause(reset_file):
                 return self.REBOOT_CAUSE_HARDWARE_OTHER, reset_cause
+
+        if self._verify_reboot_cause(self.reboot_by_software):
+            logger.log_info("Hardware reboot cause: the system was rebooted due to software requesting")
+        else:
+            logger.log_info("Hardware reboot cause: no hardware reboot cause found")
 
         return self.REBOOT_CAUSE_NON_HARDWARE, ''
 


### PR DESCRIPTION
Ignore reset_sw_reset which indicates rebooted by software.

**- What I did**
Correct reboot cause when reboot via power cycle by ignoring reset_sw_reset.

process-reboot-cause has the following logic:
1. check whether there is a hardware reboot cause, if so treats it as the final reboot-cause
2. otherwise it checks the previously saved reboot cause files in /host/reboot-cause/

Currently we implement "reboot" command via using power cycle. After a power-cycle reboot the reset_sw_reset contains a "1". Originally chassis reboot-cause handling treats it as a hardware-caused reboot and returns it to process-reboot-cause. In this case, the process-reboot-cause treats it as the reboot cause which is wrong.

To resolve that, just ignore reset_sw_reset.

**- How I did it**
Ignore reset_sw_reset

**- How to verify it**

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
