### PR TITLE
[Mellanox]Correct the wrong log identifiers of platform daemons

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -39,8 +39,7 @@ REBOOT_CAUSE_ROOT = HWMGMT_SYSTEM_ROOT
 REBOOT_CAUSE_FILE_LENGTH = 1
 
 # Global logger class instance
-SYSLOG_IDENTIFIER = "mlnx-chassis-api"
-logger = Logger(SYSLOG_IDENTIFIER)
+logger = Logger()
 
 # magic code defnition for port number, qsfp port position of each hwsku
 # port_position_tuple = (PORT_START, QSFP_PORT_START, PORT_END, PORT_IN_BLOCK, EEPROM_OFFSET)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -17,8 +17,7 @@ except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
 # Global logger class instance
-SYSLOG_IDENTIFIER = "mlnx-psu-api"
-logger = Logger(SYSLOG_IDENTIFIER)
+logger = Logger()
 
 psu_list = []
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -188,8 +188,7 @@ PORT_TYPE_MASK = 0xF0000000
 NVE_MASK = PORT_TYPE_MASK & (PORT_TYPE_NVE << PORT_TYPE_OFFSET)
 
 # Global logger class instance
-SYSLOG_IDENTIFIER = "mlnx-sfp"
-logger = Logger(SYSLOG_IDENTIFIER)
+logger = Logger()
 
 class SFP(SfpBase):
     """Platform-specific SFP class"""

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp_event.py
@@ -11,8 +11,6 @@ import select
 from python_sdk_api.sx_api import *
 from sonic_daemon_base.daemon_base import Logger
 
-SYSLOG_IDENTIFIER = "sfp-event"
-
 SDK_SFP_STATE_IN = 0x1
 SDK_SFP_STATE_OUT = 0x2
 STATUS_PLUGIN = '1'
@@ -34,7 +32,7 @@ SDK_DAEMON_READY_FILE = '/tmp/sdk_ready'
 
 PMPE_PACKET_SIZE = 2000
 
-logger = Logger(SYSLOG_IDENTIFIER)
+logger = Logger()
 
 class sfp_event:
     ''' Listen to plugin/plugout cable events '''

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal.py
@@ -19,8 +19,7 @@ except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
 # Global logger class instance
-SYSLOG_IDENTIFIER = "mlnx-thermal-api"
-logger = Logger(SYSLOG_IDENTIFIER)
+logger = Logger()
 
 THERMAL_DEV_CATEGORY_CPU_CORE = "cpu_core"
 THERMAL_DEV_CATEGORY_CPU_PACK = "cpu_pack"

--- a/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
+++ b/src/sonic-daemon-base/sonic_daemon_base/daemon_base.py
@@ -48,9 +48,12 @@ def db_connect(db):
 #
 
 class Logger(object):
-    def __init__(self, syslog_identifier):
+    def __init__(self, syslog_identifier = None):
         self.syslog = syslog
-        self.syslog.openlog(ident=syslog_identifier, logoption=self.syslog.LOG_NDELAY, facility=self.syslog.LOG_DAEMON)
+        if syslog_identifier is None:
+            self.syslog.openlog()
+        else:
+            self.syslog.openlog(ident=syslog_identifier, logoption=self.syslog.LOG_NDELAY, facility=self.syslog.LOG_DAEMON)
 
     def __del__(self):
         self.syslog.closelog()


### PR DESCRIPTION
**- What I did**
Correct the wrong log identifiers of platform daemons on Mellanox platform
Originally the Logger class was introduced for the daemons running in pmon docker to provide them the ability to log message in an easy way with log identifier initialized as daemon's name.
When platform API is developed the Logger was also used by them with log identifiers initialized as the classes' name.
However, the logger identifier is global of the entire process scope, which means only one instance of log identifier for the entire daemon. As a result, the classes who is lastly loaded will have its classname set to the daemon's log identifier, causing the identifier incorrect in the logging message.
Since the original meaning of log identifier is the name of the daemon but not the modules, only daemons is legal to set the log identifier. All classes shouldn't set the log identifier when instantiate Logger class.

**- How I did it**
Don't touch log identifier when initialized by classes in platform API.

**- How to verify it**
config reload and check whether the pmon logs are correct.

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
