### PR TITLE
[Mellanox]support led for fan/psu and fan direction

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -89,9 +89,9 @@ class Chassis(ChassisBase):
 
         for index in range(num_of_fan):
             if multi_rotor_in_drawer:
-                fan = Fan(index, index/2)
+                fan = Fan(self.sku_name, index, index/2)
             else:
-                fan = Fan(index, index)
+                fan = Fan(self.sku_name, index, index)
             self._fan_list.append(fan)
 
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -36,7 +36,7 @@ HWMGMT_SYSTEM_ROOT = '/var/run/hw-management/system/'
 
 MST_DEVICE_NAME_PATTERN = '/dev/mst/mt[0-9]*_pciconf0'
 MST_DEVICE_RE_PATTERN = '/dev/mst/mt([0-9]*)_pciconf0'
-CHIP_SPECTRUM1 = '53100'
+CHIP_SPECTRUM1 = '52100'
 
 #reboot cause related definitions
 REBOOT_CAUSE_ROOT = HWMGMT_SYSTEM_ROOT
@@ -98,9 +98,9 @@ class Chassis(ChassisBase):
             raise RuntimeError("Can't get chip type due to {} not found".format(MST_DEVICE_NAME_PATTERN))
         m = re.search(MST_DEVICE_RE_PATTERN, mst_dev_list[0])
         if m.group(1) == CHIP_SPECTRUM1:
-            has_fan_dir = True
-        else:
             has_fan_dir = False
+        else:
+            has_fan_dir = True
 
         for index in range(num_of_fan):
             if multi_rotor_in_drawer:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -14,6 +14,7 @@ try:
     from sonic_daemon_base.daemon_base import Logger
     from os import listdir
     from os.path import isfile, join
+    from glob import glob
     import sys
     import io
     import re
@@ -32,6 +33,10 @@ EEPROM_CACHE_ROOT = '/var/cache/sonic/decode-syseeprom'
 EEPROM_CACHE_FILE = 'syseeprom_cache'
 
 HWMGMT_SYSTEM_ROOT = '/var/run/hw-management/system/'
+
+MST_DEVICE_NAME_PATTERN = '/dev/mst/mt[0-9]*_pciconf0'
+MST_DEVICE_RE_PATTERN = '/dev/mst/mt([0-9]*)_pciconf0'
+CHIP_SPECTRUM1 = '53100'
 
 #reboot cause related definitions
 REBOOT_CAUSE_ROOT = HWMGMT_SYSTEM_ROOT
@@ -87,11 +92,21 @@ class Chassis(ChassisBase):
         num_of_fan, num_of_drawer = self._extract_num_of_fans_and_fan_drawers()
         multi_rotor_in_drawer = num_of_fan > num_of_drawer
 
+        # Fan's direction is supported on spectrum 1 devices for now
+        mst_dev_list = glob(MST_DEVICE_NAME_PATTERN)
+        if not mst_dev_list:
+            raise RuntimeError("Can't get chip type due to {} not found".format(MST_DEVICE_NAME_PATTERN))
+        m = re.search(MST_DEVICE_RE_PATTERN, mst_dev_list[0])
+        if m.group(1) == CHIP_SPECTRUM1:
+            has_fan_dir = True
+        else:
+            has_fan_dir = False
+
         for index in range(num_of_fan):
             if multi_rotor_in_drawer:
-                fan = Fan(self.sku_name, index, index/2)
+                fan = Fan(has_fan_dir, index, index/2)
             else:
-                fan = Fan(self.sku_name, index, index)
+                fan = Fan(has_fan_dir, index, index)
             self._fan_list.append(fan)
 
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -36,7 +36,7 @@ HWMGMT_SYSTEM_ROOT = '/var/run/hw-management/system/'
 
 MST_DEVICE_NAME_PATTERN = '/dev/mst/mt[0-9]*_pciconf0'
 MST_DEVICE_RE_PATTERN = '/dev/mst/mt([0-9]*)_pciconf0'
-CHIP_SPECTRUM1 = '52100'
+SPECTRUM1_CHIP_ID = '52100'
 
 #reboot cause related definitions
 REBOOT_CAUSE_ROOT = HWMGMT_SYSTEM_ROOT
@@ -97,7 +97,7 @@ class Chassis(ChassisBase):
         if not mst_dev_list:
             raise RuntimeError("Can't get chip type due to {} not found".format(MST_DEVICE_NAME_PATTERN))
         m = re.search(MST_DEVICE_RE_PATTERN, mst_dev_list[0])
-        if m.group(1) == CHIP_SPECTRUM1:
+        if m.group(1) == SPECTRUM1_CHIP_ID:
             has_fan_dir = False
         else:
             has_fan_dir = True

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -92,7 +92,7 @@ class Chassis(ChassisBase):
         num_of_fan, num_of_drawer = self._extract_num_of_fans_and_fan_drawers()
         multi_rotor_in_drawer = num_of_fan > num_of_drawer
 
-        # Fan's direction is supported on spectrum 1 devices for now
+        # Fan's direction isn't supported on spectrum 1 devices for now
         mst_dev_list = glob(MST_DEVICE_NAME_PATTERN)
         if not mst_dev_list:
             raise RuntimeError("Can't get chip type due to {} not found".format(MST_DEVICE_NAME_PATTERN))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -15,14 +15,14 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-LED_ON = 1
-LED_OFF = 0
+LED_ON = '1'
+LED_OFF = '0'
 
 PWM_MAX = 255
 
 FAN_PATH = "/var/run/hw-management/thermal/"
 LED_PATH = "/var/run/hw-management/led/"
-# fan_dir only exist SPC2 switches
+# fan_dir only exist Spectrum 2 switches
 FAN_DIR = "/var/run/hw-management/system/fan_dir"
 
 skus_with_fan_dir = {'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800'}
@@ -63,7 +63,7 @@ class Fan(FanBase):
 
     def get_direction(self):
         """
-        Retrieves the direction of fan
+        Retrieves the fan's direction
 
         Returns:
             A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
@@ -264,7 +264,7 @@ class Fan(FanBase):
         try:
             if color == self.STATUS_LED_COLOR_GREEN:
                 with open(os.path.join(LED_PATH, self.fan_green_led_path), 'w') as fan_led:
-                    fan_led.write(str(LED_ON))
+                    fan_led.write(LED_ON)
                     status = True
             elif color == self.STATUS_LED_COLOR_RED:
                 # Some fan don't support red led but support orange led, in this case we set led to orange
@@ -275,7 +275,7 @@ class Fan(FanBase):
                 else:
                     return False
                 with open(led_path, 'w') as fan_led:
-                    fan_led.write(str(LED_ON))
+                    fan_led.write(LED_ON)
                     status = True
             elif color == self.STATUS_LED_COLOR_OFF:
                 if self.STATUS_LED_COLOR_GREEN in led_cap_list:
@@ -310,15 +310,15 @@ class Fan(FanBase):
 
         try:
             with open(os.path.join(LED_PATH, self.fan_green_led_path), 'r') as fan_led:
-                if '0' != fan_led.read().rstrip('\n'):
+                if LED_OFF != fan_led.read().rstrip('\n'):
                     return self.STATUS_LED_COLOR_GREEN
             if self.STATUS_LED_COLOR_RED in led_cap_list:
                 with open(os.path.join(LED_PATH, self.fan_red_led_path), 'r') as fan_led:
-                    if '0' != fan_led.read().rstrip('\n'):
+                    if LED_OFF != fan_led.read().rstrip('\n'):
                         return self.STATUS_LED_COLOR_RED
             if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
                 with open(os.path.join(LED_PATH, self.fan_orange_led_path), 'r') as fan_led:
-                    if '0' != fan_led.read().rstrip('\n'):
+                    if LED_OFF != fan_led.read().rstrip('\n'):
                         return self.STATUS_LED_COLOR_RED
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to read led status for fan {} due to {}".format(self.index, repr(e)))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -22,16 +22,23 @@ PWM_MAX = 255
 
 FAN_PATH = "/var/run/hw-management/thermal/"
 LED_PATH = "/var/run/hw-management/led/"
+# fan_dir only exist SPC2 switches
+FAN_DIR = "/var/run/hw-management/system/fan_dir"
+
+skus_with_fan_dir = {'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800'}
 
 class Fan(FanBase):
     """Platform-specific Fan class"""
-    def __init__(self, fan_index, drawer_index = 1, psu_fan = False):
+
+    STATUS_LED_COLOR_ORANGE = "orange"
+
+    def __init__(self, sku, fan_index, drawer_index = 1, psu_fan = False):
         # API index is starting from 0, Mellanox platform index is starting from 1
         self.index = fan_index + 1
         self.drawer_index = drawer_index + 1
 
         self.is_psu_fan = psu_fan
-        
+
         self.fan_min_speed_path = "fan{}_min".format(self.index)
         if not self.is_psu_fan:
             self.fan_speed_get_path = "fan{}_speed_get".format(self.index)
@@ -48,6 +55,45 @@ class Fan(FanBase):
         self.fan_orange_led_path = "led_fan{}_orange".format(self.drawer_index)
         self.fan_pwm_path = "pwm1"
         self.fan_led_cap_path = "led_fan{}_capability".format(self.drawer_index)
+        if sku in skus_with_fan_dir:
+            self.fan_dir = FAN_DIR
+        else:
+            self.fan_dir = None
+
+
+    def get_direction(self):
+        """
+        Retrieves the direction of fan
+
+        Returns:
+            A string, either FAN_DIRECTION_INTAKE or FAN_DIRECTION_EXHAUST
+            depending on fan direction
+
+        Notes:
+            What Mellanox calls forward: 
+            Air flows from fans side to QSFP side, for example: MSN2700-CS2F
+            which means intake in community
+            What Mellanox calls reverse:
+            Air flow from QSFP side to fans side, for example: MSN2700-CS2R
+            which means exhaust in community
+            According to hw-mgmt:
+                1 stands for forward, in other words intake
+                0 stands for reverse, in other words exhaust
+        """
+        if not self.fan_dir or self.is_psu_fan:
+            raise NotImplementedError
+
+        try:
+            with open(os.path.join(self.fan_dir), 'r') as fan_dir:
+                fan_dir_bits = int(fan_dir.read())
+                fan_mask = 1 << self.index - 1
+                if fan_dir_bits & fan_mask:
+                    return self.FAN_DIRECTION_INTAKE
+                else:
+                    return self.FAN_DIRECTION_EXHAUST
+        except (ValueError, IOError) as e:
+            raise RuntimeError("Failed to read fan direction status to {}".format(repr(e)))
+
 
     def get_status(self):
         """
@@ -67,6 +113,7 @@ class Fan(FanBase):
                 status = 0
 
         return status == 1
+
 
     def get_presence(self):
         """
@@ -89,7 +136,8 @@ class Fan(FanBase):
                 status = 0
 
         return status == 1
-    
+
+
     def _get_min_speed_in_rpm(self):
         speed = 0
         try:
@@ -99,7 +147,8 @@ class Fan(FanBase):
             speed = 0
         
         return speed
-    
+
+
     def _get_max_speed_in_rpm(self):
         speed = 0
         try:
@@ -109,6 +158,7 @@ class Fan(FanBase):
             speed = 0
         
         return speed
+
 
     def get_speed(self):
         """
@@ -128,6 +178,7 @@ class Fan(FanBase):
         speed = 100*speed_in_rpm/max_speed_in_rpm
 
         return speed
+
 
     def get_target_speed(self):
         """
@@ -150,6 +201,7 @@ class Fan(FanBase):
         speed = int(round(pwm*100.0/PWM_MAX))
         
         return speed
+
 
     def set_speed(self, speed):
         """
@@ -176,7 +228,8 @@ class Fan(FanBase):
             status = False
 
         return status
-    
+
+
     def _get_led_capability(self):
         cap_list = None
         try:
@@ -187,6 +240,7 @@ class Fan(FanBase):
             status = 0
         
         return cap_list
+
 
     def set_status_led(self, color):
         """
@@ -208,31 +262,69 @@ class Fan(FanBase):
             return False
         status = False
         try:
-            if color == 'green':
+            if color == self.STATUS_LED_COLOR_GREEN:
                 with open(os.path.join(LED_PATH, self.fan_green_led_path), 'w') as fan_led:
                     fan_led.write(str(LED_ON))
-            elif color == 'red':
+                    status = True
+            elif color == self.STATUS_LED_COLOR_RED:
                 # Some fan don't support red led but support orange led, in this case we set led to orange
-                if 'red' in led_cap_list:
+                if self.STATUS_LED_COLOR_RED in led_cap_list:
                     led_path = os.path.join(LED_PATH, self.fan_red_led_path)
-                elif 'orange' in led_cap_list:
+                elif self.STATUS_LED_COLOR_ORANGE in led_cap_list:
                     led_path = os.path.join(LED_PATH, self.fan_orange_led_path)
                 else:
                     return False
                 with open(led_path, 'w') as fan_led:
                     fan_led.write(str(LED_ON))
+                    status = True
+            elif color == self.STATUS_LED_COLOR_OFF:
+                if self.STATUS_LED_COLOR_GREEN in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.fan_green_led_path), 'w') as fan_led:
+                        fan_led.write(str(LED_OFF))
+                if self.STATUS_LED_COLOR_RED in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.fan_red_led_path), 'w') as fan_led:
+                        fan_led.write(str(LED_OFF))
+                if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.fan_orange_led_path), 'w') as fan_led:
+                        fan_led.write(str(LED_OFF))
 
-            elif color == 'off':
-                with open(os.path.join(LED_PATH, self.fan_green_led_path), 'w') as fan_led:
-                    fan_led.write(str(LED_OFF))
-
-                with open(os.path.join(LED_PATH, self.fan_red_led_path), 'w') as fan_led:
-                    fan_led.write(str(LED_OFF))
+                status = True
             else:
                 status = False
         except (ValueError, IOError):
-                    status = False
+            status = False
+
         return status
+
+
+    def get_status_led(self):
+        """
+        Gets the state of the fan status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+        """
+        led_cap_list = self._get_led_capability()
+        if led_cap_list is None:
+            return self.STATUS_LED_COLOR_OFF
+
+        try:
+            with open(os.path.join(LED_PATH, self.fan_green_led_path), 'r') as fan_led:
+                if '0' != fan_led.read().rstrip('\n'):
+                    return self.STATUS_LED_COLOR_GREEN
+            if self.STATUS_LED_COLOR_RED in led_cap_list:
+                with open(os.path.join(LED_PATH, self.fan_red_led_path), 'r') as fan_led:
+                    if '0' != fan_led.read().rstrip('\n'):
+                        return self.STATUS_LED_COLOR_RED
+            if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                with open(os.path.join(LED_PATH, self.fan_orange_led_path), 'r') as fan_led:
+                    if '0' != fan_led.read().rstrip('\n'):
+                        return self.STATUS_LED_COLOR_RED
+        except (ValueError, IOError) as e:
+            raise RuntimeError("Failed to read led status for fan {} due to {}".format(self.index, repr(e)))
+
+        return self.STATUS_LED_COLOR_OFF
+
 
     def get_speed_tolerance(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -25,14 +25,12 @@ LED_PATH = "/var/run/hw-management/led/"
 # fan_dir only exist Spectrum 2 switches
 FAN_DIR = "/var/run/hw-management/system/fan_dir"
 
-skus_with_fan_dir = {'ACS-MSN3700', 'ACS-MSN3700C', 'ACS-MSN3800'}
-
 class Fan(FanBase):
     """Platform-specific Fan class"""
 
     STATUS_LED_COLOR_ORANGE = "orange"
 
-    def __init__(self, sku, fan_index, drawer_index = 1, psu_fan = False):
+    def __init__(self, has_fan_dir, fan_index, drawer_index = 1, psu_fan = False):
         # API index is starting from 0, Mellanox platform index is starting from 1
         self.index = fan_index + 1
         self.drawer_index = drawer_index + 1
@@ -55,7 +53,7 @@ class Fan(FanBase):
         self.fan_orange_led_path = "led_fan{}_orange".format(self.drawer_index)
         self.fan_pwm_path = "pwm1"
         self.fan_led_cap_path = "led_fan{}_capability".format(self.drawer_index)
-        if sku in skus_with_fan_dir:
+        if has_fan_dir:
             self.fan_dir = FAN_DIR
         else:
             self.fan_dir = None
@@ -81,7 +79,7 @@ class Fan(FanBase):
                 0 stands for reverse, in other words exhaust
         """
         if not self.fan_dir or self.is_psu_fan:
-            raise NotImplementedError
+            return self.FAN_DIRECTION_NOT_APPLICABLE
 
         try:
             with open(os.path.join(self.fan_dir), 'r') as fan_dir:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -16,8 +16,8 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
-LED_ON = 1
-LED_OFF = 0
+LED_ON = '1'
+LED_OFF = '0'
 
 # Global logger class instance
 logger = Logger()
@@ -223,7 +223,7 @@ class Psu(PsuBase):
         try:
             if color == self.STATUS_LED_COLOR_GREEN:
                 with open(os.path.join(LED_PATH, self.psu_green_led_path), 'w') as psu_led:
-                    psu_led.write(str(LED_ON))
+                    psu_led.write(LED_ON)
                     status = True
             elif color == self.STATUS_LED_COLOR_RED:
                 # Some fan don't support red led but support orange led, in this case we set led to orange
@@ -234,7 +234,7 @@ class Psu(PsuBase):
                 else:
                     return False
                 with open(led_path, 'w') as psu_led:
-                    psu_led.write(str(LED_ON))
+                    psu_led.write(LED_ON)
                     status = True
             elif color == self.STATUS_LED_COLOR_OFF:
                 if self.STATUS_LED_COLOR_GREEN in led_cap_list:
@@ -269,15 +269,15 @@ class Psu(PsuBase):
 
         try:
             with open(os.path.join(LED_PATH, self.psu_green_led_path), 'r') as psu_led:
-                if '0' != psu_led.read().rstrip('\n'):
+                if LED_OFF != psu_led.read().rstrip('\n'):
                     return self.STATUS_LED_COLOR_GREEN
             if self.STATUS_LED_COLOR_RED in led_cap_list:
                 with open(os.path.join(LED_PATH, self.psu_red_led_path), 'r') as psu_led:
-                    if '0' != psu_led.read().rstrip('\n'):
+                    if LED_OFF != psu_led.read().rstrip('\n'):
                         return self.STATUS_LED_COLOR_RED
             if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
                 with open(os.path.join(LED_PATH, self.psu_orange_led_path), 'r') as psu_led:
-                    if '0' != psu_led.read().rstrip('\n'):
+                    if LED_OFF != psu_led.read().rstrip('\n'):
                         return self.STATUS_LED_COLOR_RED
         except (ValueError, IOError) as e:
             raise RuntimeError("Failed to read led status for psu due to {}".format(repr(e)))

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -16,6 +16,9 @@ try:
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
 
+LED_ON = 1
+LED_OFF = 0
+
 # Global logger class instance
 logger = Logger()
 
@@ -24,6 +27,8 @@ psu_list = []
 PSU_CURRENT = "current"
 PSU_VOLTAGE = "voltage"
 PSU_POWER = "power"
+
+LED_PATH = "/var/run/hw-management/led/"
 
 # SKUs with unplugable PSUs:
 # 1. don't have psuX_status and should be treated as always present
@@ -50,6 +55,9 @@ psu_profile_list = [
 
 class Psu(PsuBase):
     """Platform-specific Psu class"""
+
+    STATUS_LED_COLOR_ORANGE = "orange"
+
     def __init__(self, psu_index, sku):
         global psu_list
         PsuBase.__init__(self)
@@ -90,9 +98,15 @@ class Psu(PsuBase):
             psu_presence = os.path.join(self.psu_path, psu_presence)
             self.psu_presence = psu_presence
 
-        fan = Fan(psu_index, psu_index, True)
+        fan = Fan(sku, psu_index, psu_index, True)
         if fan.get_presence():
             self._fan = fan
+
+        self.psu_green_led_path = "led_psu_green"
+        self.psu_red_led_path = "led_psu_red"
+        self.psu_orange_led_path = "led_psu_orange"
+        self.psu_led_cap_path = "led_psu_capability"
+
 
     def _read_generic_file(self, filename, len):
         """
@@ -106,6 +120,7 @@ class Psu(PsuBase):
             logger.log_info("Fail to read file {} due to {}".format(filename, repr(e)))
         return result
 
+
     def get_powergood_status(self):
         """
         Retrieves the operational status of power supply unit (PSU) defined
@@ -116,6 +131,7 @@ class Psu(PsuBase):
         status = self._read_generic_file(os.path.join(self.psu_path, self.psu_oper_status), 0)
 
         return status == 1
+
 
     def get_presence(self):
         """
@@ -130,6 +146,7 @@ class Psu(PsuBase):
             status = self._read_generic_file(self.psu_presence, 0)
             return status == 1
 
+
     def get_voltage(self):
         """
         Retrieves current PSU voltage output
@@ -143,6 +160,7 @@ class Psu(PsuBase):
             return float(voltage) / 1000
         else:
             return None
+
 
     def get_current(self):
         """
@@ -169,3 +187,99 @@ class Psu(PsuBase):
             return float(power) / 1000000
         else:
             return None
+
+
+    def _get_led_capability(self):
+        cap_list = None
+        try:
+            with open(os.path.join(LED_PATH, self.psu_led_cap_path), 'r') as psu_led_cap:
+                    caps = psu_led_cap.read()
+                    cap_list = caps.split()
+        except (ValueError, IOError):
+            status = 0
+        
+        return cap_list
+
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the PSU status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+
+        Notes:
+            Only one led for all PSUs.
+        """
+        led_cap_list = self._get_led_capability()
+        if led_cap_list is None:
+            return False
+
+        status = False
+        try:
+            if color == self.STATUS_LED_COLOR_GREEN:
+                with open(os.path.join(LED_PATH, self.psu_green_led_path), 'w') as psu_led:
+                    psu_led.write(str(LED_ON))
+                    status = True
+            elif color == self.STATUS_LED_COLOR_RED:
+                # Some fan don't support red led but support orange led, in this case we set led to orange
+                if self.STATUS_LED_COLOR_RED in led_cap_list:
+                    led_path = os.path.join(LED_PATH, self.psu_red_led_path)
+                elif self.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    led_path = os.path.join(LED_PATH, self.psu_orange_led_path)
+                else:
+                    return False
+                with open(led_path, 'w') as psu_led:
+                    psu_led.write(str(LED_ON))
+                    status = True
+            elif color == self.STATUS_LED_COLOR_OFF:
+                if self.STATUS_LED_COLOR_GREEN in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.psu_green_led_path), 'w') as psu_led:
+                        psu_led.write(str(LED_OFF))
+                if self.STATUS_LED_COLOR_RED in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.psu_red_led_path), 'w') as psu_led:
+                        psu_led.write(str(LED_OFF))
+                if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                    with open(os.path.join(LED_PATH, self.psu_orange_led_path), 'w') as psu_led:
+                        psu_led.write(str(LED_OFF))
+
+                status = True
+            else:
+                status = False
+        except (ValueError, IOError):
+            status = False
+
+        return status
+
+
+    def get_status_led(self):
+        """
+        Gets the state of the PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+        """
+        led_cap_list = self._get_led_capability()
+        if led_cap_list is None:
+            return self.STATUS_LED_COLOR_OFF
+
+        try:
+            with open(os.path.join(LED_PATH, self.psu_green_led_path), 'r') as psu_led:
+                if '0' != psu_led.read().rstrip('\n'):
+                    return self.STATUS_LED_COLOR_GREEN
+            if self.STATUS_LED_COLOR_RED in led_cap_list:
+                with open(os.path.join(LED_PATH, self.psu_red_led_path), 'r') as psu_led:
+                    if '0' != psu_led.read().rstrip('\n'):
+                        return self.STATUS_LED_COLOR_RED
+            if self.STATUS_LED_COLOR_ORANGE in led_cap_list:
+                with open(os.path.join(LED_PATH, self.psu_orange_led_path), 'r') as psu_led:
+                    if '0' != psu_led.read().rstrip('\n'):
+                        return self.STATUS_LED_COLOR_RED
+        except (ValueError, IOError) as e:
+            raise RuntimeError("Failed to read led status for psu due to {}".format(repr(e)))
+
+        return self.STATUS_LED_COLOR_OFF


### PR DESCRIPTION
**- What I did**
support led for fan/psu and fan direction
It depends on [add fan direction "not applicable" #4](https://github.com/stephenxs/sonic-platform-common/pull/4)
**- How I did it**

**- How to verify it**
set led for fan/psu and then check
get fan direction
[test-led-fandir.txt](https://github.com/Azure/sonic-buildimage/files/3867135/test-led-fandir.txt)

**- Description for the changelog**

**- A picture of a cute animal (not mandatory but encouraged)**
