### PR TITLE
[Mellanox]Take advantage of sdk variable to customize the location where sdk_socket exists.

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -197,11 +197,15 @@ start() {
 {%- if sonic_asic_platform == "mellanox" %}
 {%- if docker_container_name == "syncd" %}
         -v /var/log/mellanox/sniffer:/var/log/mellanox/sniffer:rw \
-        -v mlnx_sdk_socket:/tmp \
+        -v mlnx_sdk_socket:/var/run/sx_sdk \
+        -v mlnx_sdk_ready:/tmp \
         -v /dev/shm:/dev/shm:rw \
+        -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
 {%- elif docker_container_name == "pmon" %}
         -v /var/run/hw-management:/var/run/hw-management:rw \
-        -v mlnx_sdk_socket:/tmp \
+        -v mlnx_sdk_socket:/var/run/sx_sdk \
+        -v mlnx_sdk_ready:/tmp \
+        -e SX_API_SOCKET_FILE=/var/run/sx_sdk/sx_api.sock \
         -v /dev/shm:/dev/shm:rw \
 {%- else %}
         --tmpfs /tmp \

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -4,6 +4,8 @@ FROM docker-syncd-mlnx
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN mkdir -p /var/run/sx_sdk
+
 RUN apt-get purge -y syncd
 
 {% if docker_syncd_mlnx_rpc_debs.strip() -%}

--- a/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx/Dockerfile.j2
@@ -4,6 +4,8 @@ FROM docker-config-engine-stretch
 ARG docker_container_name
 RUN [ -f /etc/rsyslog.conf ] && sed -ri "s/%syslogtag%/$docker_container_name#%syslogtag%/;" /etc/rsyslog.conf
 
+RUN mkdir -p /var/run/sx_sdk
+
 ## Make apt-get non-interactive
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
**- What I did**
Take advantage of an SDK environment variable to customize the location where sdk_socket exists.
In the latest SDK sdk_socket has been moved from /tmp to /var/run which is a better place to contain this kind of file. 
However, this prevents the subdirs under /var/run from being mapped to different volumes. To resolve this, we take advantage of an SDK variable to designate the location of sdk_socket.
This requires every process that requires to access sdk_socket have this environment variable defined. However, to define environment variable for each process is less scalable. We take advantage of the docker scope environment variable to avoid that.

**- How I did it**

**- How to verify it**
run sfputil commands.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
