### PR TITLE
[Mellanox] Fix issue: ptf_nn_agent isn't able to start in syncd-rpc docker in buster

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -29,6 +29,7 @@ RUN apt-get update \
  && apt-get -y install  \
     net-tools           \
     python-pip          \
+    python-setuptools   \
     build-essential     \
     libssl-dev          \
     libffi-dev          \
@@ -47,7 +48,8 @@ RUN apt-get update \
  && rm -f 1.0.0.tar.gz  \
  && pip install cffi==1.7.0    \
  && pip install --upgrade cffi==1.7.0 \
- && pip install nnpy    \
+ && pip2 install wheel  \
+ && pip2 install nnpy    \
  && mkdir -p /opt       \
  && cd /opt             \
  && wget https://raw.githubusercontent.com/p4lang/ptf/master/ptf_nn/ptf_nn_agent.py \

--- a/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
+++ b/platform/mellanox/docker-syncd-mlnx-rpc/Dockerfile.j2
@@ -46,8 +46,8 @@ RUN apt-get update \
  && cd ..               \
  && rm -fr nanomsg-1.0.0 \
  && rm -f 1.0.0.tar.gz  \
- && pip install cffi==1.7.0    \
- && pip install --upgrade cffi==1.7.0 \
+ && pip2 install cffi==1.7.0    \
+ && pip2 install --upgrade cffi==1.7.0 \
  && pip2 install wheel  \
  && pip2 install nnpy    \
  && mkdir -p /opt       \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
Fix issue: ptf_nn_agent isn't able to start in syncd-rpc docker in buster by installing python-dev, cffi and nnpy for python 2 explicitly.

**- How I did it**

**- How to verify it**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
