### PR TITLE
[monit] Avoid monit error log by removing "-l" from monit_swss

### DIFF
--- a/dockers/docker-orchagent/base_image_files/monit_swss
+++ b/dockers/docker-orchagent/base_image_files/monit_swss
@@ -40,7 +40,7 @@ check program swss|intfmgrd with path "/usr/bin/process_checker swss /usr/bin/in
 check program swss|portmgrd with path "/usr/bin/process_checker swss /usr/bin/portmgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
 
-check program swss|buffermgrd with path "/usr/bin/process_checker swss /usr/bin/buffermgrd -l"
+check program swss|buffermgrd with path "/usr/bin/process_checker swss /usr/bin/buffermgrd"
     if status != 0 for 5 times within 5 cycles then alert repeat every 1 cycles
 
 check program swss|nbrmgrd with path "/usr/bin/process_checker swss /usr/bin/nbrmgrd"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Avoid the following error messages while dynamic buffer calculation is enabled
```
ERR monit[491]: 'swss|buffermgrd' status failed (1) -- '/usr/bin/buffermgrd -l' is not running in host
```

#### How I did it
Change `/usr/bin/buffermgrd -l` to `/usr/bin/buffermgrd`. The buffermgrd is started by `-l` for traditional model or `-a` for dynamic model.
So we need to use the common section of both.

#### How to verify it
Manually test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

