### PR TITLE
[201911] Install haveged in 201911

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -303,7 +303,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     makedumpfile            \
     conntrack               \
     python-pip              \
-    jq
+    jq                      \
+    haveged
 
 
 if [[ $CONFIGURED_ARCH == amd64 ]]; then


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Install haveged package on 201911/stretch to accelerate the entropy collect process

Recently, we found on some of our testbeds the entropy collecting process finishes more than 60 seconds after the system started.
This results in swss not able to start sporadically.
To install haveged can accelerate the entropy collect process.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

