### PR TITLE
[Mellanox] Adjust Makefile for python-sdk-api for the purpose of supporting both python2 and python3

### DIFF
--- a/platform/mellanox/sdk-src/python-sdk-api/Makefile
+++ b/platform/mellanox/sdk-src/python-sdk-api/Makefile
@@ -18,7 +18,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		./autogen.sh
 	fi
 
-	debuild -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
+	debuild -e PYTHON_INTERPRETERS="\"python2 python3\"" -b -us -uc -j$(SONIC_CONFIG_MAKE_JOBS)
 
 	popd
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

- SDK team won't migrate examples to python3 for now but the examples are widely used in SONiC.
  This means we can not phase out python2 until all the examples have been migrated to python3.
- As a result, we need to compile SDK with both python2 and python3 support.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it
Build the image and check whether python2 and python3 are both supported by SDK api.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

