### PR TITLE
[Mellanox] Bug fix: exception occurred during chassis object being destroyed

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -73,6 +73,7 @@ class Chassis(ChassisBase):
         self.sfp_event_initialized = False
         self.reboot_cause_initialized = False
         self.sdk_handle = None
+        self.deinitialize_sdk_handle = None
         logger.log_info("Chassis loaded successfully")
 
 
@@ -80,9 +81,8 @@ class Chassis(ChassisBase):
         if self.sfp_event_initialized:
             self.sfp_event.deinitialize()
 
-        if self.sdk_handle:
-            from sonic_platform.sfp import deinitialize_sdk_handle
-            deinitialize_sdk_handle(self.sdk_handle)
+        if self.deinitialize_sdk_handle:
+            self.deinitialize_sdk_handle(self.sdk_handle)
 
 
     def initialize_psu(self):
@@ -140,10 +140,12 @@ class Chassis(ChassisBase):
 
     def get_sdk_handle(self):
         if not self.sdk_handle:
-            from sonic_platform.sfp import initialize_sdk_handle
+            from sonic_platform.sfp import initialize_sdk_handle, deinitialize_sdk_handle
             self.sdk_handle = initialize_sdk_handle()
             if self.sdk_handle is None:
                 logger.log_error('Failed to open SDK handle')
+            else:
+                self.deinitialize_sdk_handle = deinitialize_sdk_handle
         return self.sdk_handle
 
 


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The following error message is observed during chassis object being destroyed
```
Exception ignored in: <function Chassis.__del__ at 0x7fd22165cd08>
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/sonic_platform/chassis.py", line 83, in __del__
ImportError: sys.meta_path is None, Python is likely shutting down
```

The chassis tries to import deinitialize_sdk_handle during being destroyed for the purpose of releasing the sdk_handle.
However, importing another module during shutting down can cause the error because some of the fundamental infrastructures are no longer available.

This error occurs when a chassis object is created and then destroyed in the Python shell.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
To fix it, record the deinitialize_sdk_handle in the chassis object when sdk_handle is being initialized and call the deinitialize handler when the chassis object is being destroyed

#### How to verify it
Manually test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

