### PR TITLE
[Mellanox] Support get_error_status for SFP modules

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -10,6 +10,7 @@
 
 try:
     import subprocess
+    import os
     from sonic_platform_base.sfp_base import SfpBase
     from sonic_platform_base.sonic_eeprom import eeprom_dts
     from sonic_platform_base.sonic_sfp.sff8472 import sff8472InterfaceId
@@ -33,6 +34,18 @@ try:
     from python_sdk_api.sxd_api import *
     from python_sdk_api.sx_api import *
 except ImportError as e:
+    pass
+
+try:
+    if os.environ["PLATFORM_API_UNIT_TESTING"] == "1":
+        # Unable to import SDK constants under unit test
+        # Define them here
+        SX_PORT_MODULE_STATUS_INITIALIZING = 0
+        SX_PORT_MODULE_STATUS_PLUGGED = 1
+        SX_PORT_MODULE_STATUS_UNPLUGGED = 2
+        SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR = 3
+        SX_PORT_MODULE_STATUS_PLUGGED_DISABLED = 4
+except KeyError:
     pass
 
 # definitions of the offset and width for values in XCVR info eeprom
@@ -388,7 +401,7 @@ class SFP(SfpBase):
     # Read out any bytes from any offset
     def _read_eeprom_specific_bytes(self, offset, num_bytes):
         eeprom_raw = []
-        ethtool_cmd = "ethtool -m sfp{} hex on offset {} length {}".format(self.index, offset, num_bytes)
+        ethtool_cmd = "ethtool -m sfp{} hex on offset {} length {} 2>/dev/null".format(self.index, offset, num_bytes)
         try:
             output = subprocess.check_output(ethtool_cmd, 
                                              shell=True, 
@@ -2158,3 +2171,66 @@ class SFP(SfpBase):
             bool: True if it is replaceable.
         """
         return True
+
+    def _get_error_code(self):
+        """
+        Get error code of the SFP module
+
+        Returns:
+            The error code fetch from SDK API
+        """
+        module_id_info_list = new_sx_mgmt_module_id_info_t_arr(1)
+        module_info_list = new_sx_mgmt_phy_module_info_t_arr(1)
+
+        module_id_info = sx_mgmt_module_id_info_t()
+        module_id_info.slot_id = 0
+        module_id_info.module_id = self.sdk_index
+        sx_mgmt_module_id_info_t_arr_setitem(module_id_info_list, 0, module_id_info)
+
+        rc = sx_mgmt_phy_module_info_get(self.sdk_handle, module_id_info_list, 1, module_info_list)
+        assert SX_STATUS_SUCCESS == rc, "sx_mgmt_phy_module_info_get failed, error code {}".format(rc)
+
+        mod_info = sx_mgmt_phy_module_info_t_arr_getitem(module_info_list, 0)
+        return mod_info.module_state.oper_state, mod_info.module_state.error_type
+
+    @classmethod
+    def _get_error_description_dict(cls):
+        return {0: 'Power budget exceeded',
+                1: 'Long range for non Mellanox cable or module',
+                2: 'Bus stuck (I2C data or clock shorted)',
+                3: 'Bad or unsupported eeprom',
+                4: 'Enforce part number list',
+                5: 'Unsupported cable',
+                6: 'High temperature',
+                7: 'Bad cable (module/cable is shorted)',
+                8: 'PMD type not enabled',
+                12: 'PCIE system power slot exceeded',
+                255: 'OK'
+        }
+
+    def get_error_description(self):
+        """
+        Get error description
+
+        Args:
+            error_code: The error code returned by _get_error_code
+
+        Returns:
+            The error description
+        """
+        oper_status, error_code = self._get_error_code()
+        if oper_status == SX_PORT_MODULE_STATUS_INITIALIZING:
+            error_description = "Initializing"
+        elif oper_status == SX_PORT_MODULE_STATUS_PLUGGED:
+            error_description = "OK"
+        elif oper_status == SX_PORT_MODULE_STATUS_UNPLUGGED:
+            error_description = "Unplugged"
+        elif oper_status == SX_PORT_MODULE_STATUS_PLUGGED_DISABLED:
+            error_description = "Disabled"
+        elif oper_status == SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR:
+            error_description_dict = self._get_error_description_dict()
+            if error_code in error_description_dict:
+                error_description = error_description_dict[error_code]
+            else:
+                error_description = "Unknown error ({})".format(error_code)
+        return error_description

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -8,8 +8,10 @@ test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 sys.path.insert(0, modules_path)
 
+os.environ["PLATFORM_API_UNIT_TESTING"] = "1"
+
 from sonic_py_common import device_info
-from sonic_platform.sfp import SFP
+from sonic_platform.sfp import SFP, SX_PORT_MODULE_STATUS_INITIALIZING, SX_PORT_MODULE_STATUS_PLUGGED, SX_PORT_MODULE_STATUS_UNPLUGGED, SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR, SX_PORT_MODULE_STATUS_PLUGGED_DISABLED
 from sonic_platform.chassis import Chassis
 
 
@@ -26,10 +28,14 @@ def mock_get_sdk_handle(self):
         self.sdk_handle = 1
     return self.sdk_handle
 
+def mock_get_sfp_error_code(self):
+    return self.oper_code, self.error_code
+
+
 device_info.get_platform = mock_get_platform
 SFP._read_eeprom_specific_bytes = mock_read_eeprom_specific_bytes
+SFP._get_error_code = mock_get_sfp_error_code
 Chassis.get_sdk_handle = mock_get_sdk_handle
-
 
 def test_sfp_partial_and_then_full_initialize():
     """
@@ -82,3 +88,35 @@ def test_sfp_full_initialize_without_partial():
     # Verify when get_sfp is called, the SFP modules won't be initialized again
     sfp1 = allsfp[0]
     assert sfp1 == chassis.get_sfp(1)
+
+
+def test_sfp_get_error_status():
+    chassis = Chassis()
+
+    # Fetch an SFP module to test
+    sfp = chassis.get_sfp(1)
+
+    description_dict = sfp._get_error_description_dict()
+
+    sfp.oper_code = SX_PORT_MODULE_STATUS_PLUGGED_WITH_ERROR
+    for error in description_dict.keys():
+        sfp.error_code = error
+        description = sfp.get_error_description()
+
+        assert description == description_dict[sfp.error_code]
+
+    sfp.error_code = -1
+    description = sfp.get_error_description()
+    assert description == "Unknown error (-1)"
+
+    expected_description_list = [
+        (SX_PORT_MODULE_STATUS_INITIALIZING, "Initializing"),
+        (SX_PORT_MODULE_STATUS_PLUGGED, "OK"),
+        (SX_PORT_MODULE_STATUS_UNPLUGGED, "Unplugged"),
+        (SX_PORT_MODULE_STATUS_PLUGGED_DISABLED, "Disabled")
+    ]
+    for oper_code, expected_description in expected_description_list:
+        sfp.oper_code = oper_code
+        description = sfp.get_error_description()
+
+        assert description == expected_description


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This to expose the error status of SFP modules to CLI
The platform API calls SDK API to fetch the error status
The CLI will call platform API and provide user-friendly output

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
A new platform API is introduced:
```
def get_error_status(self)
    """
    Get error status of the SFP module
    Returns:
        string: represent the error code
    """
```
The possible error description of this API:

- `Unplugged`: SFP module is unplugged
- `Initializing`: SFP module is under initializing
- `OK`: SFP module is plugged without error
- `Disabled`: SFP module is plugged but disabled
- Other value: SFP module is plugged with an error detected

#### How to verify it
Manually test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

