### PR TITLE
[Reclaim unused buffer] Support zero buffer profiles

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
@@ -155,34 +155,31 @@
 {% endfor %}
 {% if port_names_inactive|length > 0 %}
 ,
+{% if dynamic_mode is defined %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|3-4": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-{% endif %}
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|0-2": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-{% endif %}
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|5-6": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-{% endif %}
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% else %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% endif %}
 {% endif %}
     }
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
@@ -174,7 +174,17 @@
 {% endfor %}
 {% else %}
 {% for port in port_names_inactive.split(',') %}
-        "{{ port }}|0-7": {
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }{% if not loop.last %},{% endif %}
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
@@ -10,7 +10,6 @@
         "ingress_lossless_pool": {
             {% if dynamic_mode is not defined -%}
             "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
             {% endif -%}
             "type": "ingress",
             "mode": "dynamic"
@@ -99,6 +98,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}": {
@@ -110,6 +110,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names_active.split(',') %}
@@ -118,6 +119,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}": {
@@ -129,6 +131,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}
 
@@ -150,6 +153,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|3-4": {
@@ -179,6 +183,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}
 
@@ -195,6 +200,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 {%- for port in port_names_inactive.split(',') %}
        {%- if loop.first -%},{%- endif -%}
 {% if dynamic_mode is defined %}
@@ -211,5 +217,6 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
@@ -60,7 +60,7 @@
         "egress_lossy_zero_profile" : {
           "pool":"[BUFFER_POOL|egress_lossy_pool]",
           "size":"0",
-          "dynamic_ty":"-8"
+          "dynamic_th":"-8"
         },
         {% endif -%}
         "ingress_lossless_profile": {

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2
@@ -1,0 +1,215 @@
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        {% if dynamic_mode is not defined and PORT_INACTIVE is defined and PORT_INACTIVE|length > 0 -%}
+        "ingress_zero_pool" : {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        {% endif -%}
+        "ingress_lossless_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ ingress_lossless_pool_size }}",
+            "xoff": "{{ ingress_lossless_pool_xoff }}",
+            {% endif -%}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "ingress_lossy_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ ingress_lossy_pool_size }}",
+            {% endif -%}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "{{ egress_lossless_pool_size }}",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ egress_lossy_pool_size }}",
+            {% endif -%}
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        {% if dynamic_mode is not defined and PORT_INACTIVE is defined and PORT_INACTIVE|length > 0 -%}
+        "ingress_lossy_pg_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_zero_pool]",
+          "size":"0",
+          "static_th":"0"
+        },
+        "ingress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossy_pool]",
+          "size":"0",
+          "dynamic_ty":"-8"
+        },
+        {% endif -%}
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_profile_lists(port_names_active, port_names_inactive) %}
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+{% else %}
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+{% else %}
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_queue_buffers(port_names_active, port_names_inactive) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+{% endfor %}
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+{% endfor %}
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|3-4": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+{% endif %}
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-2": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|5-6": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_pg_profiles(port_names_active, port_names_inactive) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+{% if dynamic_mode is defined %}
+        "{{ port }}|3-4": {
+            "profile" : "NULL"
+        },
+{% endif %}
+        "{{ port }}|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{%- for port in port_names_inactive.split(',') %}
+       {%- if loop.first -%},{%- endif -%}
+{% if dynamic_mode is defined %}
+        "{{ port }}|3-4": {
+            "profile" : "NULL"
+        },
+{% endif %}
+       "{{ port }}|0": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t0.j2
@@ -4,109 +4,20 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '4580864' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
@@ -4,109 +4,16 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '3302912' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists(port_name) %}
+{{ defs.generate_profile_lists(port_name) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers(port_name) %}
+{{ defs.generate_queue_buffers(port_name) }}
 {%- endmacro %}
-
-

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_t1.j2
@@ -10,10 +10,14 @@
 {{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_name) %}
-{{ defs.generate_profile_lists(port_name) }}
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_name) %}
-{{ defs.generate_queue_buffers(port_name) }}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
+
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-C28D8/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D40C8S8/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -144,34 +144,31 @@
 {% endfor %}
 {% if port_names_inactive|length > 0 %}
 ,
+{% if dynamic_mode is defined %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|3-4": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-{% endif %}
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|0-2": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-{% endif %}
         },
 {% endfor %}
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|5-6": {
-{% if dynamic_mode is defined %}
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-{% else %}
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-{% endif %}
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% else %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% endif %}
 {% endif %}
     }
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -163,7 +163,17 @@
 {% endfor %}
 {% else %}
 {% for port in port_names_inactive.split(',') %}
-        "{{ port }}|0-7": {
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }{% if not loop.last %},{% endif %}
 

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -87,6 +87,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}": {
@@ -98,6 +99,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
 {% for port in port_names_active.split(',') %}
@@ -106,6 +108,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}": {
@@ -117,6 +120,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}
 
@@ -138,6 +142,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 ,
 {% for port in port_names_inactive.split(',') %}
         "{{ port }}|3-4": {
@@ -167,6 +172,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}
 
@@ -183,6 +189,7 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% if port_names_inactive|length > 0 %}
 {%- for port in port_names_inactive.split(',') %}
        {%- if loop.first -%},{%- endif -%}
 {% if dynamic_mode is defined %}
@@ -199,5 +206,6 @@
         }{% if not loop.last %},{% endif %}
 
 {% endfor %}
+{% endif %}
     }
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -40,11 +40,6 @@
           "size":"0",
           "dynamic_th":"-8"
         },
-        "ingress_lossy_zero_profile" : {
-          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-          "size":"0",
-          "dynamic_th":"-8"
-        },
         "egress_lossless_zero_profile" : {
           "pool":"[BUFFER_POOL|egress_lossless_pool]",
           "size":"0",
@@ -53,7 +48,7 @@
         "egress_lossy_zero_profile" : {
           "pool":"[BUFFER_POOL|egress_lossy_pool]",
           "size":"0",
-          "dynamic_ty":"-8"
+          "dynamic_th":"-8"
         },
         {% endif -%}
         "ingress_lossless_profile": {

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2
@@ -1,0 +1,208 @@
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        {% if dynamic_mode is not defined and PORT_INACTIVE is defined and PORT_INACTIVE|length > 0 -%}
+        "ingress_zero_pool" : {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        {% endif -%}
+        "ingress_lossless_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ ingress_lossless_pool_size }}",
+            "xoff": "{{ ingress_lossless_pool_xoff }}",
+            {% endif -%}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "{{ egress_lossless_pool_size }}",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ egress_lossy_pool_size }}",
+            {% endif -%}
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        {% if dynamic_mode is not defined and PORT_INACTIVE is defined and PORT_INACTIVE|length > 0 -%}
+        "ingress_lossy_pg_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_zero_pool]",
+          "size":"0",
+          "static_th":"0"
+        },
+        "ingress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossy_pool]",
+          "size":"0",
+          "dynamic_ty":"-8"
+        },
+        {% endif -%}
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_profile_lists(port_names_active, port_names_inactive) %}
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+{% else %}
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+{% else %}
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_queue_buffers(port_names_active, port_names_inactive) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+{% endfor %}
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+{% endfor %}
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|3-4": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+{% endif %}
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-2": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|5-6": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}
+
+{%- macro generate_pg_profiles(port_names_active, port_names_inactive) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+{% if dynamic_mode is defined %}
+        "{{ port }}|3-4": {
+            "profile" : "NULL"
+        },
+{% endif %}
+        "{{ port }}|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{%- for port in port_names_inactive.split(',') %}
+       {%- if loop.first -%},{%- endif -%}
+{% if dynamic_mode is defined %}
+        "{{ port }}|3-4": {
+            "profile" : "NULL"
+        },
+{% endif %}
+       "{{ port }}|0": {
+{% if dynamic_mode is defined %}
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+{% else %}
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    }
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t0.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '7719936' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_t1.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '9686016' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t0.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '10177536' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/Mellanox-SN2700/buffers_defaults_t1.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '13945824' %}
 {% set egress_lossy_pool_size =  '8719360' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t0.j2
@@ -4,107 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '14542848' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/buffers_defaults_t1.j2
@@ -4,107 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '11622400' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t0.j2
@@ -4,107 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '13924352' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/buffers_defaults_t1.j2
@@ -4,107 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '12457984' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '25866240' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-C64/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '24219648' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '20017152' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D112C8/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '19124224' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '24576000' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D24C52/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '22597632' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t0.j2
@@ -4,97 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '24360960' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            "size": "{{ egress_lossy_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C49S1/buffers_defaults_t1.j2
@@ -4,97 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '22380544' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            "size": "{{ egress_lossy_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '24360960' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D28C50/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '22380544' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_pool_xoff }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '53379072' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
@@ -4,103 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '52723712' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '47587328' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '46702592' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '50995200' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
@@ -4,101 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '50143232' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
+{%- endmacro %}
 
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t0.j2
@@ -4,109 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '26451968' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/buffers_defaults_t1.j2
@@ -4,109 +4,20 @@
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '20627456' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
-{%- endmacro %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
 
 {%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "ingress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{{ defs.generate_buffer_pool_and_profiles() }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
+{%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4800-r0/ACS-MSN4800/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4800-r0/ACS-MSN4800/buffers_defaults_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/ACS-MSN2700/buffers_defaults_objects.j2

--- a/dockers/docker-orchagent/buffermgrd.sh
+++ b/dockers/docker-orchagent/buffermgrd.sh
@@ -3,14 +3,16 @@
 BUFFER_CALCULATION_MODE=$(redis-cli -n 4 hget "DEVICE_METADATA|localhost" buffer_model)
 
 if [ "$BUFFER_CALCULATION_MODE" == "dynamic" ]; then
+    BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json"
     if [ -f /etc/sonic/peripheral_table.json ]; then
-        BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json -p /etc/sonic/peripheral_table.json"
-    else
-        BUFFERMGRD_ARGS="-a /etc/sonic/asic_table.json"
+        BUFFERMGRD_PERIPHERIAL_ARGS=" -p /etc/sonic/peripheral_table.json"
+    fi
+    if [ -f /etc/sonic/zero_profiles.json ]; then
+        BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
     fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
 fi
 
-exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS}
+exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_PERIPHERIAL_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -173,7 +173,7 @@ def
 {% if defs.generate_queue_buffers is defined %}
 {{ defs.generate_queue_buffers(port_names_active) }}
 {% elif defs.generate_queue_buffers_with_inactive_ports is defined %}
-{{ defs.generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) }},
+{{ defs.generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) }}
 {% else %}
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}

--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -21,6 +21,30 @@ def
 {%-     set switch_role      = '' %}
 {%- endif -%}
 
+{%- set PORT_ALL  = [] %}
+
+{%- if PORT is not defined %}
+    {%- if defs.generate_port_lists(PORT_ALL) %} {% endif %}
+{%- else %}
+    {%- for port in PORT %}
+        {%- if PORT_ALL.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{%- set PORT_ACTIVE  = [] %}
+{%- set PORT_INACTIVE  = [] %}
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in PORT_ALL %}
+        {%- if port in DEVICE_NEIGHBOR.keys() %}
+            {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+        {%- else %}
+            {%- if PORT_INACTIVE.append(port) %}{%- endif %}
+        {%- endif %}
+    {%- endfor %}
+{%- endif %}
+
 {# Import default values from device HWSKU folder #}
 {%- import 'buffers_defaults_%s.j2' % filename_postfix as defs with context %}
 
@@ -93,30 +117,17 @@ def
     {%- endif %}
 {%- endmacro %}
 
-{%- set PORT_ALL  = [] %}
-
-{%- if PORT is not defined %}
-    {%- if defs.generate_port_lists(PORT_ALL) %} {% endif %}
-{%- else %}
-    {%- for port in PORT %}
-        {%- if PORT_ALL.append(port) %}{%- endif %}
-    {%- endfor %}
-{%- endif %}
-
-{%- set PORT_ACTIVE  = [] %}
-{%- if DEVICE_NEIGHBOR is not defined %}
-    {%- set PORT_ACTIVE = PORT_ALL %}
-{%- else %}
-    {%- for port in DEVICE_NEIGHBOR.keys() %}
-        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
-    {%- endfor %}
-{%- endif %}
-
 {%- set port_names_list_active  = [] %}
 {%- for port in PORT_ACTIVE %}
     {%- if port_names_list_active.append(port) %}{%- endif %}
 {%- endfor %}
 {%- set port_names_active  = port_names_list_active  | join(',') %}
+
+{%- set port_names_list_inactive  = [] %}
+{%- for port in PORT_INACTIVE %}
+    {%- if port_names_list_inactive.append(port) %}{%- endif %}
+{%- endfor %}
+{%- set port_names_inactive  = port_names_list_inactive  | join(',') %}
 
 {
     "CABLE_LENGTH": {
@@ -135,10 +146,14 @@ def
 
 {%- if defs.generate_profile_lists is defined %}
 {{ defs.generate_profile_lists(port_names_active) }},
+{% elif defs.generate_profile_lists_with_inactive_ports is defined %}
+{{ defs.generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) }},
 {% endif %}
 
 {%- if defs.generate_pg_profils is defined %}
 {{ defs.generate_pg_profils(port_names_active) }}
+{% elif defs.generate_pg_profiles_with_inactive_ports is defined %}
+{{ defs.generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) }},
 {% else %}
     "BUFFER_PG": {
 {% for port in PORT_ACTIVE %}
@@ -157,6 +172,8 @@ def
 
 {% if defs.generate_queue_buffers is defined %}
 {{ defs.generate_queue_buffers(port_names_active) }}
+{% elif defs.generate_queue_buffers_with_inactive_ports is defined %}
+{{ defs.generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) }},
 {% else %}
     "BUFFER_QUEUE": {
 {% for port in PORT_ACTIVE %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -297,6 +297,9 @@ start() {
     if [ ! -f /etc/sonic/peripheral_table.json ] && [ -f /usr/share/sonic/device/$PLATFORM/port_peripheral_config.j2 ]; then
         sonic-cfggen -d -t /usr/share/sonic/device/$PLATFORM/port_peripheral_config.j2 > /etc/sonic/peripheral_table.json
     fi
+    if [ ! -f /etc/sonic/zero_profiles.json ] && [ -f /usr/share/sonic/templates/zero_profiles.j2 ]; then
+        sonic-cfggen -d -t /usr/share/sonic/device/$PLATFORM/zero_profiles.j2 > /etc/sonic/zero_profiles.json
+    fi
     {%- endif %}
 
     # In Multi ASIC platforms the global database config file database_global.json will exist.

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -529,6 +529,11 @@ if [ -f platform/{{ sonic_asic_platform }}/peripheral_table.j2 ]
 then
     sudo cp platform/{{ sonic_asic_platform }}/peripheral_table.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/peripheral_table.j2
 fi
+
+if [ -f platform/{{ sonic_asic_platform }}/zero_profiles.j2 ]
+then
+    sudo cp platform/{{ sonic_asic_platform }}/zero_profiles.j2 $FILESYSTEM_ROOT/usr/share/sonic/templates/zero_profiles.j2
+fi
 {% endif %}
 
 # Copy hostname configuration scripts

--- a/platform/mellanox/zero_profiles.j2
+++ b/platform/mellanox/zero_profiles.j2
@@ -48,7 +48,7 @@
         "OP": "SET"
     },
     {
-        "ids_to_reclaim" : {
+        "control_fields" : {
             "pgs_to_apply_zero_profile":"0",
             "ingress_zero_profile":"[BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile]"
         },

--- a/platform/mellanox/zero_profiles.j2
+++ b/platform/mellanox/zero_profiles.j2
@@ -1,0 +1,57 @@
+[
+    {
+        "BUFFER_POOL_TABLE:ingress_zero_pool": {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile" : {
+            "pool":"[BUFFER_POOL_TABLE:ingress_zero_pool]",
+            "size":"0",
+            "static_th":"0"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:ingress_lossy_zero_profile" : {
+            "pool":"[BUFFER_POOL_TABLE:ingress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"-8"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:ingress_lossless_zero_profile" : {
+            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"-8"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:egress_lossy_zero_profile" : {
+            "pool":"[BUFFER_POOL_TABLE:egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"-8"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:egress_lossless_zero_profile" : {
+            "pool":"[BUFFER_POOL_TABLE:egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"-8"
+        },
+        "OP": "SET"
+    },
+    {
+        "ids_to_reclaim" : {
+            "pgs_to_reclaim":"0",
+            "ingress_zero_profile":"[BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile]"
+        },
+        "OP": "SET"
+    }
+]

--- a/platform/mellanox/zero_profiles.j2
+++ b/platform/mellanox/zero_profiles.j2
@@ -49,7 +49,7 @@
     },
     {
         "ids_to_reclaim" : {
-            "pgs_to_reclaim":"0",
+            "pgs_to_apply_zero_profile":"0",
             "ingress_zero_profile":"[BUFFER_PROFILE_TABLE:ingress_lossy_pg_zero_profile]"
         },
         "OP": "SET"

--- a/platform/vs/docker-sonic-vs/buffermgrd.sh
+++ b/platform/vs/docker-sonic-vs/buffermgrd.sh
@@ -10,4 +10,8 @@ else
     BUFFERMGRD_ARGS="-l /usr/share/sonic/hwsku/pg_profile_lookup.ini"
 fi
 
-exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS}
+if [ -f /etc/sonic/zero_profiles.json ]; then
+    BUFFERMGRD_ZERO_PROFILE_ARGS=" -z /etc/sonic/zero_profiles.json"
+fi
+
+exec /usr/bin/buffermgrd ${BUFFERMGRD_ARGS} ${BUFFERMGRD_ZERO_PROFILE_ARGS}

--- a/src/sonic-config-engine/tests/sample-mellanox-2410-t1-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-mellanox-2410-t1-minigraph.xml
@@ -1520,7 +1520,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1534,7 +1533,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1548,7 +1546,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1562,7 +1559,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1576,7 +1572,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1590,7 +1585,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1604,7 +1598,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1618,7 +1611,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1632,7 +1624,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1646,7 +1637,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1660,7 +1650,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1674,7 +1663,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1688,7 +1676,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1702,7 +1689,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1716,7 +1702,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1730,7 +1715,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1744,7 +1728,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1758,7 +1741,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1772,7 +1754,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1786,7 +1767,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1800,7 +1780,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1814,7 +1793,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1828,7 +1806,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1842,7 +1819,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1856,7 +1832,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1870,7 +1845,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1884,7 +1858,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1898,7 +1871,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1912,7 +1884,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1926,7 +1897,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1940,7 +1910,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1954,7 +1923,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1968,7 +1936,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1982,7 +1949,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -1996,7 +1962,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2010,7 +1975,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2024,7 +1988,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2038,7 +2001,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2052,7 +2014,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2066,7 +2027,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2080,7 +2040,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2094,7 +2053,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2108,7 +2066,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2122,7 +2079,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2136,7 +2092,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2150,7 +2105,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2164,7 +2118,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2178,7 +2131,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>25000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2192,7 +2144,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2206,7 +2157,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2220,7 +2170,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2234,7 +2183,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2248,7 +2196,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2262,7 +2209,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2276,7 +2222,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
         <a:EthernetInterface>
           <ElementType>DeviceInterface</ElementType>
@@ -2290,7 +2235,6 @@
           <PortName>0</PortName>
           <Priority>0</Priority>
               <Speed>100000</Speed>
-    
         </a:EthernetInterface>
       </EthernetInterfaces>
       <FlowControl>true</FlowControl>

--- a/src/sonic-config-engine/tests/sample-mellanox-2410-t1-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-mellanox-2410-t1-minigraph.xml
@@ -1,0 +1,2359 @@
+<DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.32</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>10.0.0.33</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::41</StartPeer>
+        <EndRouter>ARISTA01T0</EndRouter>
+        <EndPeer>FC00::42</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.0</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>10.0.0.1</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::1</StartPeer>
+        <EndRouter>ARISTA01T2</EndRouter>
+        <EndPeer>FC00::2</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.34</StartPeer>
+        <EndRouter>ARISTA02T0</EndRouter>
+        <EndPeer>10.0.0.35</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::45</StartPeer>
+        <EndRouter>ARISTA02T0</EndRouter>
+        <EndPeer>FC00::46</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.36</StartPeer>
+        <EndRouter>ARISTA03T0</EndRouter>
+        <EndPeer>10.0.0.37</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::49</StartPeer>
+        <EndRouter>ARISTA03T0</EndRouter>
+        <EndPeer>FC00::4A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.4</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>10.0.0.5</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::9</StartPeer>
+        <EndRouter>ARISTA03T2</EndRouter>
+        <EndPeer>FC00::A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.38</StartPeer>
+        <EndRouter>ARISTA04T0</EndRouter>
+        <EndPeer>10.0.0.39</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::4D</StartPeer>
+        <EndRouter>ARISTA04T0</EndRouter>
+        <EndPeer>FC00::4E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.40</StartPeer>
+        <EndRouter>ARISTA05T0</EndRouter>
+        <EndPeer>10.0.0.41</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::51</StartPeer>
+        <EndRouter>ARISTA05T0</EndRouter>
+        <EndPeer>FC00::52</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.8</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>10.0.0.9</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::11</StartPeer>
+        <EndRouter>ARISTA05T2</EndRouter>
+        <EndPeer>FC00::12</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.42</StartPeer>
+        <EndRouter>ARISTA06T0</EndRouter>
+        <EndPeer>10.0.0.43</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::55</StartPeer>
+        <EndRouter>ARISTA06T0</EndRouter>
+        <EndPeer>FC00::56</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.44</StartPeer>
+        <EndRouter>ARISTA07T0</EndRouter>
+        <EndPeer>10.0.0.45</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::59</StartPeer>
+        <EndRouter>ARISTA07T0</EndRouter>
+        <EndPeer>FC00::5A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.12</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>10.0.0.13</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::19</StartPeer>
+        <EndRouter>ARISTA07T2</EndRouter>
+        <EndPeer>FC00::1A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.46</StartPeer>
+        <EndRouter>ARISTA08T0</EndRouter>
+        <EndPeer>10.0.0.47</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::5D</StartPeer>
+        <EndRouter>ARISTA08T0</EndRouter>
+        <EndPeer>FC00::5E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.48</StartPeer>
+        <EndRouter>ARISTA09T0</EndRouter>
+        <EndPeer>10.0.0.49</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::61</StartPeer>
+        <EndRouter>ARISTA09T0</EndRouter>
+        <EndPeer>FC00::62</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.16</StartPeer>
+        <EndRouter>ARISTA09T2</EndRouter>
+        <EndPeer>10.0.0.17</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::21</StartPeer>
+        <EndRouter>ARISTA09T2</EndRouter>
+        <EndPeer>FC00::22</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.50</StartPeer>
+        <EndRouter>ARISTA10T0</EndRouter>
+        <EndPeer>10.0.0.51</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::65</StartPeer>
+        <EndRouter>ARISTA10T0</EndRouter>
+        <EndPeer>FC00::66</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.52</StartPeer>
+        <EndRouter>ARISTA11T0</EndRouter>
+        <EndPeer>10.0.0.53</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::69</StartPeer>
+        <EndRouter>ARISTA11T0</EndRouter>
+        <EndPeer>FC00::6A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.20</StartPeer>
+        <EndRouter>ARISTA11T2</EndRouter>
+        <EndPeer>10.0.0.21</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::29</StartPeer>
+        <EndRouter>ARISTA11T2</EndRouter>
+        <EndPeer>FC00::2A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.54</StartPeer>
+        <EndRouter>ARISTA12T0</EndRouter>
+        <EndPeer>10.0.0.55</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::6D</StartPeer>
+        <EndRouter>ARISTA12T0</EndRouter>
+        <EndPeer>FC00::6E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.56</StartPeer>
+        <EndRouter>ARISTA13T0</EndRouter>
+        <EndPeer>10.0.0.57</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::71</StartPeer>
+        <EndRouter>ARISTA13T0</EndRouter>
+        <EndPeer>FC00::72</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.24</StartPeer>
+        <EndRouter>ARISTA13T2</EndRouter>
+        <EndPeer>10.0.0.25</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::31</StartPeer>
+        <EndRouter>ARISTA13T2</EndRouter>
+        <EndPeer>FC00::32</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.58</StartPeer>
+        <EndRouter>ARISTA14T0</EndRouter>
+        <EndPeer>10.0.0.59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA14T0</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.60</StartPeer>
+        <EndRouter>ARISTA15T0</EndRouter>
+        <EndPeer>10.0.0.61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::79</StartPeer>
+        <EndRouter>ARISTA15T0</EndRouter>
+        <EndPeer>FC00::7A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.28</StartPeer>
+        <EndRouter>ARISTA15T2</EndRouter>
+        <EndPeer>10.0.0.29</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::39</StartPeer>
+        <EndRouter>ARISTA15T2</EndRouter>
+        <EndPeer>FC00::3A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>10.0.0.62</StartPeer>
+        <EndRouter>ARISTA16T0</EndRouter>
+        <EndPeer>10.0.0.63</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>sonic</StartRouter>
+        <StartPeer>FC00::7D</StartPeer>
+        <EndRouter>ARISTA16T0</EndRouter>
+        <EndPeer>FC00::7E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>sonic</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.33</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.1</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.35</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.37</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.5</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.39</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.41</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.9</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.43</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.45</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.13</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.47</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.49</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.17</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.51</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.53</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.21</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.55</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.25</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.29</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64001</a:ASN>
+        <a:Hostname>ARISTA01T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA01T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64002</a:ASN>
+        <a:Hostname>ARISTA02T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64003</a:ASN>
+        <a:Hostname>ARISTA03T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA03T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64004</a:ASN>
+        <a:Hostname>ARISTA04T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64005</a:ASN>
+        <a:Hostname>ARISTA05T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA05T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64006</a:ASN>
+        <a:Hostname>ARISTA06T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64007</a:ASN>
+        <a:Hostname>ARISTA07T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA07T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64008</a:ASN>
+        <a:Hostname>ARISTA08T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64009</a:ASN>
+        <a:Hostname>ARISTA09T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA09T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64010</a:ASN>
+        <a:Hostname>ARISTA10T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64011</a:ASN>
+        <a:Hostname>ARISTA11T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA11T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64012</a:ASN>
+        <a:Hostname>ARISTA12T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64013</a:ASN>
+        <a:Hostname>ARISTA13T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA13T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64014</a:ASN>
+        <a:Hostname>ARISTA14T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64015</a:ASN>
+        <a:Hostname>ARISTA15T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>65200</a:ASN>
+        <a:Hostname>ARISTA15T2</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64016</a:ASN>
+        <a:Hostname>ARISTA16T0</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>      </LoopbackIPInterfaces>
+      <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:ManagementIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.100.0.100/24</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.100.0.100/24</a:PrefixStr>
+        </a:ManagementIPInterface>
+        <a:ManagementIPInterface>
+          <Name>V6HostIP</Name>
+          <AttachTo>eth0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>fe80::9a03:9bff:fe82:f226/64</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>fe80::9a03:9bff:fe82:f226/64</a:PrefixStr>
+        </a:ManagementIPInterface>
+      </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>sonic</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <Name>PortChannel0002</Name>
+          <AttachTo>Ethernet0;Ethernet4</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0005</Name>
+          <AttachTo>Ethernet8;Ethernet12</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0008</Name>
+          <AttachTo>Ethernet16;Ethernet20</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0011</Name>
+          <AttachTo>Ethernet24;Ethernet28</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0014</Name>
+          <AttachTo>Ethernet32;Ethernet36</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0017</Name>
+          <AttachTo>Ethernet40;Ethernet44</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0020</Name>
+          <AttachTo>Ethernet48;Ethernet52</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0023</Name>
+          <AttachTo>Ethernet56;Ethernet60</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces>
+      </VlanInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet64</AttachTo>
+          <Prefix>10.0.0.32/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet64</AttachTo>
+          <Prefix>FC00::41/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0002</AttachTo>
+          <Prefix>10.0.0.0/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0002</AttachTo>
+          <Prefix>FC00::1/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet68</AttachTo>
+          <Prefix>10.0.0.34/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet68</AttachTo>
+          <Prefix>FC00::45/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet72</AttachTo>
+          <Prefix>10.0.0.36/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet72</AttachTo>
+          <Prefix>FC00::49/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0005</AttachTo>
+          <Prefix>10.0.0.4/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0005</AttachTo>
+          <Prefix>FC00::9/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet76</AttachTo>
+          <Prefix>10.0.0.38/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet76</AttachTo>
+          <Prefix>FC00::4D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet80</AttachTo>
+          <Prefix>10.0.0.40/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet80</AttachTo>
+          <Prefix>FC00::51/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0008</AttachTo>
+          <Prefix>10.0.0.8/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0008</AttachTo>
+          <Prefix>FC00::11/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet84</AttachTo>
+          <Prefix>10.0.0.42/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet84</AttachTo>
+          <Prefix>FC00::55/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet88</AttachTo>
+          <Prefix>10.0.0.44/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet88</AttachTo>
+          <Prefix>FC00::59/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0011</AttachTo>
+          <Prefix>10.0.0.12/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0011</AttachTo>
+          <Prefix>FC00::19/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet92</AttachTo>
+          <Prefix>10.0.0.46/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet92</AttachTo>
+          <Prefix>FC00::5D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet96</AttachTo>
+          <Prefix>10.0.0.48/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet96</AttachTo>
+          <Prefix>FC00::61/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0014</AttachTo>
+          <Prefix>10.0.0.16/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0014</AttachTo>
+          <Prefix>FC00::21/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet100</AttachTo>
+          <Prefix>10.0.0.50/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet100</AttachTo>
+          <Prefix>FC00::65/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet104</AttachTo>
+          <Prefix>10.0.0.52/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet104</AttachTo>
+          <Prefix>FC00::69/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0017</AttachTo>
+          <Prefix>10.0.0.20/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0017</AttachTo>
+          <Prefix>FC00::29/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet108</AttachTo>
+          <Prefix>10.0.0.54/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet108</AttachTo>
+          <Prefix>FC00::6D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet112</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet112</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0020</AttachTo>
+          <Prefix>10.0.0.24/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0020</AttachTo>
+          <Prefix>FC00::31/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet116</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet116</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet120</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet120</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0023</AttachTo>
+          <Prefix>10.0.0.28/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0023</AttachTo>
+          <Prefix>FC00::39/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Ethernet124</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>Ethernet124</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>NTP_ACL</InAcl>
+          <AttachTo>NTP</AttachTo>
+          <Type>NTP</Type>
+        </AclInterface>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel0002;PortChannel0005;PortChannel0008;PortChannel0011;PortChannel0014;PortChannel0017;PortChannel0020;PortChannel0023;Ethernet64;Ethernet68;Ethernet72;Ethernet76;Ethernet80;Ethernet84;Ethernet88;Ethernet92;Ethernet96;Ethernet100;Ethernet104;Ethernet108;Ethernet112;Ethernet116;Ethernet120;Ethernet124</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet64</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet4</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet68</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet72</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet8</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet12</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA04T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet76</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet80</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet16</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA05T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet20</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA06T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet84</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet88</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet24</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA07T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet28</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA08T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet92</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet96</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet32</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA09T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet36</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA10T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet100</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet104</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet40</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA11T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet44</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA12T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet108</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet112</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet48</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA13T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet52</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA14T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet116</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet120</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T2</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet56</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA15T2</EndDevice>
+        <EndPort>Ethernet2</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet60</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA16T0</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>sonic</StartDevice>
+        <StartPort>Ethernet124</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="LeafRouter">
+        <Hostname>sonic</Hostname>
+        <HwSku>ACS-MSN2410</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.1</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA16T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.65</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA11T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.60</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA10T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.59</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA11T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.47</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA09T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.46</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA09T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.58</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA06T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.55</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA08T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.57</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA07T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.56</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA07T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.45</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA01T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.42</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA01T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.50</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA05T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.44</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA05T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.54</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA02T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.51</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA03T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.52</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA03T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.43</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA04T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.53</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA15T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.64</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA15T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.49</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA14T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.63</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA12T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.61</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="SpineRouter">
+         <Hostname>ARISTA13T2</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.48</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="ToRRouter">
+         <Hostname>ARISTA13T0</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.62</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <AutoNegotiation>true</AutoNegotiation>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet0</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet4</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet12</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet16</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet20</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet24</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet28</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet32</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet36</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet40</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet44</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet48</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet52</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet56</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet60</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet64</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet68</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet72</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet76</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet80</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet84</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet88</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet92</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet96</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet100</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet104</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet108</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet112</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet116</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet120</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet124</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet128</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet132</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet136</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet140</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet144</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet148</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet152</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet156</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet160</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet164</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet168</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet172</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet176</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet180</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet184</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet188</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>25000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet192</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet196</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet200</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet204</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet208</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet212</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet216</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>Ethernet220</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+              <Speed>100000</Speed>
+    
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>ACS-MSN2410</HwSku>
+      <ManagementInterfaces/>
+    </DeviceInfo>
+  </DeviceInfos>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>sonic</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>QosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Profile0</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>NtpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.100.0.250</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SnmpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.0.0.9</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsGroup</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>sonicadmin</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>TacacsServer</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.100.0.20</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ForcedMgmtRoutes</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.100.0.0/16</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ErspanDestinationIpv4</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.0.0.7</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
+  <Hostname>sonic</Hostname>
+  <HwSku>ACS-MSN2410</HwSku>
+</DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample-mellanox-2700-t0-minigraph.xml
+++ b/src/sonic-config-engine/tests/sample-mellanox-2700-t0-minigraph.xml
@@ -1,0 +1,1498 @@
+<DeviceMiniGraph xmlns="Microsoft.Search.Autopilot.Evolution" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <CpgDec>
+    <IsisRouters xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    <PeeringSessions>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>10.0.0.56</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>10.0.0.57</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>FC00::71</StartPeer>
+        <EndRouter>ARISTA01T1</EndRouter>
+        <EndPeer>FC00::72</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>10.0.0.58</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>10.0.0.59</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>FC00::75</StartPeer>
+        <EndRouter>ARISTA02T1</EndRouter>
+        <EndPeer>FC00::76</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>10.0.0.60</StartPeer>
+        <EndRouter>ARISTA03T1</EndRouter>
+        <EndPeer>10.0.0.61</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>FC00::79</StartPeer>
+        <EndRouter>ARISTA03T1</EndRouter>
+        <EndPeer>FC00::7A</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <MacSec>false</MacSec>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>10.0.0.62</StartPeer>
+        <EndRouter>ARISTA04T1</EndRouter>
+        <EndPeer>10.0.0.63</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+      <BGPSession>
+        <StartRouter>mellanox-2700</StartRouter>
+        <StartPeer>FC00::7D</StartPeer>
+        <EndRouter>ARISTA04T1</EndRouter>
+        <EndPeer>FC00::7E</EndPeer>
+        <Multihop>1</Multihop>
+        <HoldTime>10</HoldTime>
+        <KeepAliveTime>3</KeepAliveTime>
+      </BGPSession>
+    </PeeringSessions>
+    <Routers xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:BGPRouterDeclaration>
+        <a:ASN>65100</a:ASN>
+        <a:Hostname>mellanox-2700</a:Hostname>
+        <a:Peers>
+          <BGPPeer>
+            <Address>10.0.0.57</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.59</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.61</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer>
+            <Address>10.0.0.63</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPSLBPassive</a:Name>
+            <a:PeersRange>10.255.0.0/25</a:PeersRange>
+          </BGPPeer>
+          <BGPPeer i:type="a:BGPPeerPassive">
+            <ElementType>BGPPeer</ElementType>
+            <Address>10.1.0.32</Address>
+            <RouteMapIn i:nil="true"/>
+            <RouteMapOut i:nil="true"/>
+            <Vrf i:nil="true"/>
+            <a:Name>BGPVac</a:Name>
+            <a:PeersRange>192.168.0.0/21</a:PeersRange>
+          </BGPPeer>
+        </a:Peers>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA01T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA02T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA03T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+      <a:BGPRouterDeclaration>
+        <a:ASN>64600</a:ASN>
+        <a:Hostname>ARISTA04T1</a:Hostname>
+        <a:RouteMaps/>
+      </a:BGPRouterDeclaration>
+    </Routers>
+  </CpgDec>
+  <DpgDec>
+    <DeviceDataPlaneInfo>
+      <IPSecTunnels/>
+      <LoopbackIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:LoopbackIPInterface>
+          <Name>HostIP</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>10.1.0.32/32</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>10.1.0.32/32</a:PrefixStr>
+        </a:LoopbackIPInterface>
+        <a:LoopbackIPInterface>
+          <Name>HostIP1</Name>
+          <AttachTo>Loopback0</AttachTo>
+          <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+            <b:IPPrefix>FC00:1::32/128</b:IPPrefix>
+          </a:Prefix>
+          <a:PrefixStr>FC00:1::32/128</a:PrefixStr>
+        </a:LoopbackIPInterface>
+      </LoopbackIPInterfaces>
+       <ManagementIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+         <a:ManagementIPInterface>
+           <Name>HostIP</Name>
+           <AttachTo>eth0</AttachTo>
+           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+             <b:IPPrefix>10.100.0.100/24</b:IPPrefix>
+           </a:Prefix>
+           <a:PrefixStr>10.100.0.0/24</a:PrefixStr>
+         </a:ManagementIPInterface>
+         <a:ManagementIPInterface>
+           <Name>V6HostIP</Name>
+           <AttachTo>eth0</AttachTo>
+           <a:Prefix xmlns:b="Microsoft.Search.Autopilot.Evolution">
+             <b:IPPrefix>fe80::526b:4bff:fecd:30cc/64</b:IPPrefix>
+           </a:Prefix>
+           <a:PrefixStr>fe80::526b:4bff:fecd:30cc/64</a:PrefixStr>
+         </a:ManagementIPInterface>
+       </ManagementIPInterfaces>
+      <ManagementVIPInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+      <MplsInterfaces/>
+      <MplsTeInterfaces/>
+      <RsvpInterfaces/>
+      <Hostname>mellanox-2700</Hostname>
+      <PortChannelInterfaces>
+        <PortChannel>
+          <Name>PortChannel0001</Name>
+          <AttachTo>etp17a</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0002</Name>
+          <AttachTo>etp17b</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0003</Name>
+          <AttachTo>etp18a</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+        <PortChannel>
+          <Name>PortChannel0004</Name>
+          <AttachTo>etp18b</AttachTo>
+          <SubInterface/>
+        </PortChannel>
+      </PortChannelInterfaces>
+      <VlanInterfaces>
+        <VlanInterface>
+          <Name>Vlan1000</Name>
+          <AttachTo>etp1b;etp2a;etp2b;etp3a;etp3b;etp4a;etp4b;etp5a;etp5b;etp6a;etp6b;etp7;etp8;etp9;etp10;etp11a;etp11b;etp12a;etp12b;etp13a;etp13b;etp14a;etp14b;etp15a</AttachTo>
+          <NoDhcpRelay>False</NoDhcpRelay>
+          <StaticDHCPRelay>0.0.0.0/0</StaticDHCPRelay>
+          <Type i:nil="true"/>
+          <DhcpRelays>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</DhcpRelays>
+          <VlanID>1000</VlanID>
+          <Tag>1000</Tag>
+          <Subnets>192.168.0.0/21</Subnets>
+        </VlanInterface>
+      </VlanInterfaces>
+      <IPInterfaces>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0001</AttachTo>
+          <Prefix>10.0.0.56/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0001</AttachTo>
+          <Prefix>FC00::71/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0002</AttachTo>
+          <Prefix>10.0.0.58/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0002</AttachTo>
+          <Prefix>FC00::75/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0003</AttachTo>
+          <Prefix>10.0.0.60/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0003</AttachTo>
+          <Prefix>FC00::79/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>PortChannel0004</AttachTo>
+          <Prefix>10.0.0.62/31</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:Name="true"/>
+          <AttachTo>PortChannel0004</AttachTo>
+          <Prefix>FC00::7D/126</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Vlan1000</AttachTo>
+          <Prefix>192.168.0.1/21</Prefix>
+        </IPInterface>
+        <IPInterface>
+          <Name i:nil="true"/>
+          <AttachTo>Vlan1000</AttachTo>
+          <Prefix>fc02:1000::1/64</Prefix>
+        </IPInterface>
+      </IPInterfaces>
+      <DataAcls/>
+      <AclInterfaces>
+        <AclInterface>
+          <InAcl>SNMP_ACL</InAcl>
+          <AttachTo>SNMP</AttachTo>
+          <Type>SNMP</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPAN</AttachTo>
+          <InAcl>Everflow</InAcl>
+          <Type>Everflow</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>ERSPANV6</AttachTo>
+          <InAcl>EverflowV6</InAcl>
+          <Type>EverflowV6</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>VTY_LINE</AttachTo>
+          <InAcl>ssh-only</InAcl>
+          <Type>SSH</Type>
+        </AclInterface>
+        <AclInterface>
+          <AttachTo>PortChannel0001;PortChannel0002;PortChannel0003;PortChannel0004</AttachTo>
+          <InAcl>DataAcl</InAcl>
+          <Type>DataPlane</Type>
+        </AclInterface>
+      </AclInterfaces>
+      <DownstreamSummaries/>
+      <DownstreamSummarySet xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+    </DeviceDataPlaneInfo>
+  </DpgDec>
+  <PngDec>
+    <DeviceInterfaceLinks>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA01T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>mellanox-2700</StartDevice>
+        <StartPort>etp17a</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA02T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>mellanox-2700</StartDevice>
+        <StartPort>etp17b</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA03T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>mellanox-2700</StartDevice>
+        <StartPort>etp18a</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>ARISTA04T1</EndDevice>
+        <EndPort>Ethernet1</EndPort>
+        <StartDevice>mellanox-2700</StartDevice>
+        <StartPort>etp18b</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp1b</EndPort>
+        <StartDevice>Servers0</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp2a</EndPort>
+        <StartDevice>Servers1</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp2b</EndPort>
+        <StartDevice>Servers2</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp3a</EndPort>
+        <StartDevice>Servers3</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp3b</EndPort>
+        <StartDevice>Servers4</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp4a</EndPort>
+        <StartDevice>Servers5</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp4b</EndPort>
+        <StartDevice>Servers6</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp5a</EndPort>
+        <StartDevice>Servers7</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp5b</EndPort>
+        <StartDevice>Servers8</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp6a</EndPort>
+        <StartDevice>Servers9</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp6b</EndPort>
+        <StartDevice>Servers10</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp7</EndPort>
+        <StartDevice>Servers11</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp8</EndPort>
+        <StartDevice>Servers12</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp9</EndPort>
+        <StartDevice>Servers13</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp10</EndPort>
+        <StartDevice>Servers14</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp11a</EndPort>
+        <StartDevice>Servers15</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp11b</EndPort>
+        <StartDevice>Servers16</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp12a</EndPort>
+        <StartDevice>Servers17</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp12b</EndPort>
+        <StartDevice>Servers18</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp13a</EndPort>
+        <StartDevice>Servers19</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp13b</EndPort>
+        <StartDevice>Servers20</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp14a</EndPort>
+        <StartDevice>Servers21</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp14b</EndPort>
+        <StartDevice>Servers22</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp15a</EndPort>
+        <StartDevice>Servers23</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp1b</EndPort>
+        <StartDevice>Servers24</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp2a</EndPort>
+        <StartDevice>Servers25</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp2b</EndPort>
+        <StartDevice>Servers26</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp3a</EndPort>
+        <StartDevice>Servers27</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp3b</EndPort>
+        <StartDevice>Servers28</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp4a</EndPort>
+        <StartDevice>Servers29</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp4b</EndPort>
+        <StartDevice>Servers30</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp5a</EndPort>
+        <StartDevice>Servers31</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp5b</EndPort>
+        <StartDevice>Servers32</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp6a</EndPort>
+        <StartDevice>Servers33</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp6b</EndPort>
+        <StartDevice>Servers34</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp7</EndPort>
+        <StartDevice>Servers35</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp8</EndPort>
+        <StartDevice>Servers36</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp9</EndPort>
+        <StartDevice>Servers37</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp10</EndPort>
+        <StartDevice>Servers38</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp11a</EndPort>
+        <StartDevice>Servers39</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp11b</EndPort>
+        <StartDevice>Servers40</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp12a</EndPort>
+        <StartDevice>Servers41</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp12b</EndPort>
+        <StartDevice>Servers42</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp13a</EndPort>
+        <StartDevice>Servers43</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp13b</EndPort>
+        <StartDevice>Servers44</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp14a</EndPort>
+        <StartDevice>Servers45</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp14b</EndPort>
+        <StartDevice>Servers46</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+      <DeviceLinkBase>
+        <ElementType>DeviceInterfaceLink</ElementType>
+        <EndDevice>mellanox-2700</EndDevice>
+        <EndPort>etp15a</EndPort>
+        <StartDevice>Servers47</StartDevice>
+        <StartPort>eth0</StartPort>
+      </DeviceLinkBase>
+    </DeviceInterfaceLinks>
+    <Devices>
+      <Device i:type="ToRRouter">
+        <Hostname>mellanox-2700</Hostname>
+        <HwSku>Mellanox-SN2700-D48C8</HwSku>
+        <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.1</a:IPPrefix>
+        </ManagementAddress>
+      </Device>
+      <Device i:type="LeafRouter">
+         <Hostname>ARISTA04T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.2</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="LeafRouter">
+         <Hostname>ARISTA03T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.3</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="LeafRouter">
+         <Hostname>ARISTA02T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.100.0.4</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+      <Device i:type="LeafRouter">
+         <Hostname>ARISTA01T1</Hostname>
+         <ManagementAddress xmlns:a="Microsoft.Search.Autopilot.NetMux">
+           <a:IPPrefix>10.213.80.121</a:IPPrefix>
+         </ManagementAddress>
+         <HwSku>Arista-VM</HwSku>
+      </Device>
+    </Devices>
+  </PngDec>
+  <DeviceInfos>
+    <DeviceInfo>
+      <AutoNegotiation>true</AutoNegotiation>
+      <EthernetInterfaces xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp1a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp1b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp2a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp2b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp3a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp3b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp4a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp4b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp5a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp5b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp6a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp6b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp7</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp8</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp9</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp10</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp11a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp11b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp12a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp12b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp13a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp13b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp14a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp14b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp15a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp15b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp16a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp16b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp17b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp18b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp19b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp20b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp21b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp22b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp23</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp24</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp25</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>100000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp26</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp27a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp27b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp28a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp28b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp29a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp29b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp30a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp30b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp31a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp31b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp32a</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+        <a:EthernetInterface>
+          <ElementType>DeviceInterface</ElementType>
+          <AlternateSpeeds i:nil="true"/>
+          <EnableAutoNegotiation>true</EnableAutoNegotiation>
+          <EnableFlowControl>true</EnableFlowControl>
+          <Index>1</Index>
+          <InterfaceName>etp32b</InterfaceName>
+          <InterfaceType i:nil="true"/>
+          <MultiPortsInterface>false</MultiPortsInterface>
+          <PortName>0</PortName>
+          <Priority>0</Priority>
+          <Speed>50000</Speed>
+        </a:EthernetInterface>
+      </EthernetInterfaces>
+      <FlowControl>true</FlowControl>
+      <Height>0</Height>
+      <HwSku>Mellanox-SN2700-D48C8</HwSku>
+      <ManagementInterfaces/>
+    </DeviceInfo>
+  </DeviceInfos>
+  <MetadataDeclaration>
+    <Devices xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution">
+      <a:DeviceMetadata>
+        <a:Name>mellanox-2700</a:Name>
+        <a:Properties>
+          <a:DeviceProperty>
+            <a:Name>DeploymentId</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>1</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>QosProfile</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>Profile0</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>DhcpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>192.0.0.1;192.0.0.2;192.0.0.3;192.0.0.4</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>SnmpResources</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.0.0.9</a:Value>
+          </a:DeviceProperty>
+          <a:DeviceProperty>
+            <a:Name>ErspanDestinationIpv4</a:Name>
+            <a:Reference i:nil="true"/>
+            <a:Value>10.0.0.7</a:Value>
+         </a:DeviceProperty>
+        </a:Properties>
+      </a:DeviceMetadata>
+    </Devices>
+    <Properties xmlns:a="http://schemas.datacontract.org/2004/07/Microsoft.Search.Autopilot.Evolution"/>
+  </MetadataDeclaration>
+  <Hostname>mellanox-2700</Hostname>
+  <HwSku>Mellanox-SN2700-D48C8</HwSku>
+</DeviceMiniGraph>

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-dell6100.json
@@ -1,4 +1,5 @@
 
+
 {
     "CABLE_LENGTH": {
         "AZURE": {
@@ -129,6 +130,9 @@
         "Ethernet5|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
+        "Ethernet22|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
         "Ethernet58|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -156,7 +160,7 @@
         "Ethernet39|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet32|0": {
+        "Ethernet14|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet15|0": {
@@ -168,19 +172,19 @@
         "Ethernet17|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet36|0": {
+        "Ethernet10|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet37|0": {
+        "Ethernet11|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet12|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet13|0": {
+        "Ethernet37|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet14|0": {
+        "Ethernet32|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet30|0": {
@@ -192,7 +196,7 @@
         "Ethernet48|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet10|0": {
+        "Ethernet36|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet42|0": {
@@ -210,9 +214,6 @@
         "Ethernet28|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet11|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet21|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -222,7 +223,7 @@
         "Ethernet23|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet22|0": {
+        "Ethernet13|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet25|0": {
@@ -264,6 +265,9 @@
         "Ethernet5|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
+        "Ethernet22|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
         "Ethernet58|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
@@ -291,7 +295,7 @@
         "Ethernet39|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet32|3-4": {
+        "Ethernet14|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet15|3-4": {
@@ -303,19 +307,19 @@
         "Ethernet17|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet36|3-4": {
+        "Ethernet10|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet37|3-4": {
+        "Ethernet11|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet12|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet13|3-4": {
+        "Ethernet37|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet14|3-4": {
+        "Ethernet32|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet30|3-4": {
@@ -327,7 +331,7 @@
         "Ethernet48|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet10|3-4": {
+        "Ethernet36|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet42|3-4": {
@@ -345,9 +349,6 @@
         "Ethernet28|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet11|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet21|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
@@ -357,7 +358,7 @@
         "Ethernet23|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet22|3-4": {
+        "Ethernet13|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet25|3-4": {
@@ -396,6 +397,9 @@
         "Ethernet5|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet22|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet58|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -423,7 +427,7 @@
         "Ethernet39|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet32|0-2": {
+        "Ethernet14|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet15|0-2": {
@@ -435,19 +439,19 @@
         "Ethernet17|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet36|0-2": {
+        "Ethernet10|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet37|0-2": {
+        "Ethernet11|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet12|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet13|0-2": {
+        "Ethernet37|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet14|0-2": {
+        "Ethernet32|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet30|0-2": {
@@ -459,7 +463,7 @@
         "Ethernet48|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet10|0-2": {
+        "Ethernet36|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet42|0-2": {
@@ -477,9 +481,6 @@
         "Ethernet28|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet11|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet21|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -489,7 +490,7 @@
         "Ethernet23|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet22|0-2": {
+        "Ethernet13|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet25|0-2": {
@@ -528,6 +529,9 @@
         "Ethernet5|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
+        "Ethernet22|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
         "Ethernet58|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -555,7 +559,7 @@
         "Ethernet39|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet32|5-6": {
+        "Ethernet14|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet15|5-6": {
@@ -567,19 +571,19 @@
         "Ethernet17|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet36|5-6": {
+        "Ethernet10|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet37|5-6": {
+        "Ethernet11|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet12|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet13|5-6": {
+        "Ethernet37|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet14|5-6": {
+        "Ethernet32|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet30|5-6": {
@@ -591,7 +595,7 @@
         "Ethernet48|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet10|5-6": {
+        "Ethernet36|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet42|5-6": {
@@ -609,9 +613,6 @@
         "Ethernet28|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet11|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet21|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -621,7 +622,7 @@
         "Ethernet23|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet22|5-6": {
+        "Ethernet13|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet25|5-6": {

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2410.json
@@ -3,62 +3,62 @@
 {
     "CABLE_LENGTH": {
         "AZURE": {
-            "Ethernet0": "5m",
-            "Ethernet2": "5m",
-            "Ethernet4": "5m",
-            "Ethernet6": "5m",
-            "Ethernet8": "5m",
-            "Ethernet10": "5m",
-            "Ethernet12": "5m",
-            "Ethernet14": "5m",
-            "Ethernet16": "5m",
-            "Ethernet18": "5m",
-            "Ethernet20": "5m",
-            "Ethernet22": "5m",
-            "Ethernet24": "5m",
-            "Ethernet28": "5m",
-            "Ethernet32": "5m",
-            "Ethernet36": "5m",
-            "Ethernet40": "5m",
-            "Ethernet42": "5m",
-            "Ethernet44": "5m",
-            "Ethernet46": "5m",
-            "Ethernet48": "5m",
-            "Ethernet50": "5m",
-            "Ethernet52": "5m",
-            "Ethernet54": "5m",
-            "Ethernet56": "5m",
-            "Ethernet58": "5m",
-            "Ethernet60": "5m",
-            "Ethernet62": "5m",
+            "Ethernet180": "5m",
+            "Ethernet8": "300m",
+            "Ethernet44": "300m",
+            "Ethernet184": "5m",
+            "Ethernet188": "5m",
+            "Ethernet0": "300m",
+            "Ethernet4": "300m",
+            "Ethernet108": "40m",
+            "Ethernet100": "40m",
+            "Ethernet128": "5m",
+            "Ethernet104": "40m",
+            "Ethernet40": "300m",
+            "Ethernet96": "40m",
+            "Ethernet124": "40m",
+            "Ethernet148": "5m",
+            "Ethernet92": "40m",
+            "Ethernet120": "40m",
+            "Ethernet220": "5m",
+            "Ethernet144": "5m",
+            "Ethernet52": "300m",
+            "Ethernet160": "5m",
+            "Ethernet140": "5m",
+            "Ethernet56": "300m",
+            "Ethernet164": "5m",
+            "Ethernet76": "40m",
+            "Ethernet72": "40m",
             "Ethernet64": "40m",
-            "Ethernet66": "40m",
+            "Ethernet32": "300m",
+            "Ethernet16": "300m",
+            "Ethernet36": "300m",
+            "Ethernet12": "300m",
+            "Ethernet196": "5m",
+            "Ethernet192": "5m",
+            "Ethernet200": "5m",
             "Ethernet68": "40m",
-            "Ethernet70": "40m",
-            "Ethernet72": "5m",
-            "Ethernet74": "5m",
-            "Ethernet76": "5m",
-            "Ethernet78": "5m",
-            "Ethernet80": "5m",
-            "Ethernet82": "5m",
-            "Ethernet84": "5m",
-            "Ethernet86": "5m",
-            "Ethernet88": "5m",
-            "Ethernet92": "5m",
-            "Ethernet96": "5m",
-            "Ethernet100": "5m",
-            "Ethernet104": "5m",
-            "Ethernet106": "5m",
-            "Ethernet108": "5m",
-            "Ethernet110": "5m",
-            "Ethernet112": "5m",
-            "Ethernet114": "5m",
-            "Ethernet116": "5m",
-            "Ethernet118": "5m",
-            "Ethernet120": "5m",
-            "Ethernet122": "5m",
-            "Ethernet124": "5m",
-            "Ethernet126": "5m"
+            "Ethernet168": "5m",
+            "Ethernet24": "300m",
+            "Ethernet116": "40m",
+            "Ethernet80": "40m",
+            "Ethernet112": "40m",
+            "Ethernet84": "40m",
+            "Ethernet152": "5m",
+            "Ethernet136": "5m",
+            "Ethernet156": "5m",
+            "Ethernet204": "5m",
+            "Ethernet132": "5m",
+            "Ethernet48": "300m",
+            "Ethernet172": "5m",
+            "Ethernet216": "5m",
+            "Ethernet176": "5m",
+            "Ethernet212": "5m",
+            "Ethernet28": "300m",
+            "Ethernet88": "40m",
+            "Ethernet60": "300m",
+            "Ethernet20": "300m",
+            "Ethernet208": "5m"
         }
     },
 
@@ -69,8 +69,12 @@
             "size": "0"
         },
         "ingress_lossless_pool": {
-            "size": "7719936",
-            "xoff": "1032192",
+            "size": "3302912",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "ingress_lossy_pool": {
+            "size": "3302912",
             "type": "ingress",
             "mode": "dynamic"
         },
@@ -80,7 +84,7 @@
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "7719936",
+            "size": "3302912",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -93,6 +97,11 @@
         },
         "ingress_lossless_zero_profile" : {
           "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossy_pool]",
           "size":"0",
           "dynamic_th":"-8"
         },
@@ -112,7 +121,7 @@
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
             "size":"0",
             "dynamic_th":"3"
         },
@@ -133,1022 +142,1022 @@
         }
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-        "Ethernet2": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet4": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet6": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
         "Ethernet8": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet10": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet12": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet14": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet16": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet18": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet20": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet22": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet24": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet28": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet32": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet36": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet40": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet42": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet44": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet46": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet48": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet50": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet52": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet54": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet56": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet64": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet66": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet68": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet70": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-,
         "Ethernet0": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet58": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet60": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet62": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet72": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet74": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet76": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet78": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet80": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet82": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet84": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet86": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet88": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet92": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet96": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet100": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet104": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet106": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet4": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet108": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet110": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet112": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet114": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet116": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet118": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet120": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet122": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet126": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet52": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet56": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet12": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet20": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        }
+,
+        "Ethernet180": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet184": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet188": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet128": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet148": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet220": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet144": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet160": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet140": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet164": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet196": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet192": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet200": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet168": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet152": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet136": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet156": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet204": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet132": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet172": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet216": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet176": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet212": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet208": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
         }
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-        "Ethernet2": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet4": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet6": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet8": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet10": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet12": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet14": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet16": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet18": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet20": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet22": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet24": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet28": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet32": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet36": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet40": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet42": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet44": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet46": {
+        "Ethernet0": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet48": {
+        "Ethernet4": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet50": {
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet124": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet120": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet52": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet54": {
+        "Ethernet56": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet56": {
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet72": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet64": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet66": {
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet12": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet68": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet70": {
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet20": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         }
 ,
-        "Ethernet0": {
+        "Ethernet180": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58": {
+        "Ethernet184": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60": {
+        "Ethernet188": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62": {
+        "Ethernet128": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72": {
+        "Ethernet148": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74": {
+        "Ethernet220": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76": {
+        "Ethernet144": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78": {
+        "Ethernet160": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80": {
+        "Ethernet140": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82": {
+        "Ethernet164": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84": {
+        "Ethernet196": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86": {
+        "Ethernet192": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88": {
+        "Ethernet200": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92": {
+        "Ethernet168": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96": {
+        "Ethernet152": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100": {
+        "Ethernet136": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104": {
+        "Ethernet156": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106": {
+        "Ethernet204": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108": {
+        "Ethernet132": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110": {
+        "Ethernet172": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112": {
+        "Ethernet216": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet114": {
+        "Ethernet176": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116": {
+        "Ethernet212": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet118": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet120": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet122": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet126": {
+        "Ethernet208": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     },
     "BUFFER_PG": {
-        "Ethernet2|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet4|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet6|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet8|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet10|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet12|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet14|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet16|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet18|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet20|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet22|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet24|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet28|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet32|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet36|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet40|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet42|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet44|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet46|0": {
+        "Ethernet0|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet48|0": {
+        "Ethernet4|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet50|0": {
+        "Ethernet108|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet100|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet104|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet40|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet96|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet124|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet92|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet120|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet52|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet54|0": {
+        "Ethernet56|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet56|0": {
+        "Ethernet76|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet72|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet64|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet66|0": {
+        "Ethernet32|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet16|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet36|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet12|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet68|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet70|0": {
+        "Ethernet24|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet116|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet80|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet112|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet84|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet48|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet28|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet88|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet60|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet20|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         }
-,       "Ethernet0|0": {
+,       "Ethernet180|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet58|0": {
+       "Ethernet184|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet60|0": {
+       "Ethernet188|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet62|0": {
+       "Ethernet128|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet72|0": {
+       "Ethernet148|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet74|0": {
+       "Ethernet220|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet76|0": {
+       "Ethernet144|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet78|0": {
+       "Ethernet160|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet80|0": {
+       "Ethernet140|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet82|0": {
+       "Ethernet164|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet84|0": {
+       "Ethernet196|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet86|0": {
+       "Ethernet192|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet88|0": {
+       "Ethernet200|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet92|0": {
+       "Ethernet168|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet96|0": {
+       "Ethernet152|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet100|0": {
+       "Ethernet136|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet104|0": {
+       "Ethernet156|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet106|0": {
+       "Ethernet204|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet108|0": {
+       "Ethernet132|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet110|0": {
+       "Ethernet172|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet112|0": {
+       "Ethernet216|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet114|0": {
+       "Ethernet176|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet116|0": {
+       "Ethernet212|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet118|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet120|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet122|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet124|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet126|0": {
+       "Ethernet208|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         }
     },
 
     "BUFFER_QUEUE": {
-        "Ethernet2|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet4|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet6|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet10|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet12|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet14|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet18|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet22|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet24|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet28|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet32|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet36|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet42|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet44|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet46|3-4": {
+        "Ethernet0|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet48|3-4": {
+        "Ethernet4|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet50|3-4": {
+        "Ethernet108|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet100|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet104|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet40|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet96|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet124|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet92|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet120|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet52|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet54|3-4": {
+        "Ethernet56|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet56|3-4": {
+        "Ethernet76|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet72|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet64|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet66|3-4": {
+        "Ethernet32|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet16|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet36|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet12|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet68|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet70|3-4": {
+        "Ethernet24|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet2|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        "Ethernet116|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet4|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        "Ethernet80|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet6|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        "Ethernet112|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet84|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet48|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet28|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet88|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet60|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet20|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet10|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet12|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet14|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet18|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet22|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet24|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet28|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet32|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet36|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet42|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet44|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet46|0-2": {
+        "Ethernet0|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet48|0-2": {
+        "Ethernet4|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet50|0-2": {
+        "Ethernet108|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet100|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet104|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet40|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet96|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet124|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet92|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet120|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet52|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet54|0-2": {
+        "Ethernet56|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet56|0-2": {
+        "Ethernet76|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet72|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet64|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet66|0-2": {
+        "Ethernet32|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet68|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet70|0-2": {
+        "Ethernet24|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet2|5-6": {
+        "Ethernet116|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet4|5-6": {
+        "Ethernet80|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet6|5-6": {
+        "Ethernet112|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet84|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet88|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet60|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet8|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet10|5-6": {
+        "Ethernet44|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet12|5-6": {
+        "Ethernet0|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet14|5-6": {
+        "Ethernet4|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet16|5-6": {
+        "Ethernet108|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet18|5-6": {
+        "Ethernet100|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet22|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet24|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet28|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet32|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet36|5-6": {
+        "Ethernet104|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet40|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet42|5-6": {
+        "Ethernet96|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet44|5-6": {
+        "Ethernet124|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet46|5-6": {
+        "Ethernet92|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet48|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet50|5-6": {
+        "Ethernet120|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet52|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet54|5-6": {
+        "Ethernet56|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet56|5-6": {
+        "Ethernet76|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet72|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet64|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet66|5-6": {
+        "Ethernet32|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet68|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet70|5-6": {
+        "Ethernet24|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet116|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet80|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet112|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet84|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet88|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet60|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
 ,
-        "Ethernet0|3-4": {
+        "Ethernet180|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet58|3-4": {
+        "Ethernet184|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet60|3-4": {
+        "Ethernet188|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet62|3-4": {
+        "Ethernet128|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet72|3-4": {
+        "Ethernet148|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet74|3-4": {
+        "Ethernet220|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet76|3-4": {
+        "Ethernet144|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet78|3-4": {
+        "Ethernet160|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet80|3-4": {
+        "Ethernet140|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet82|3-4": {
+        "Ethernet164|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet84|3-4": {
+        "Ethernet196|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet86|3-4": {
+        "Ethernet192|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet88|3-4": {
+        "Ethernet200|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet92|3-4": {
+        "Ethernet168|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet96|3-4": {
+        "Ethernet152|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet100|3-4": {
+        "Ethernet136|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet104|3-4": {
+        "Ethernet156|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet106|3-4": {
+        "Ethernet204|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet108|3-4": {
+        "Ethernet132|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet110|3-4": {
+        "Ethernet172|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet112|3-4": {
+        "Ethernet216|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet114|3-4": {
+        "Ethernet176|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet116|3-4": {
+        "Ethernet212|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet118|3-4": {
+        "Ethernet208|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet120|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet122|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet124|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet126|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet0|0-2": {
+        "Ethernet180|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58|0-2": {
+        "Ethernet184|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|0-2": {
+        "Ethernet188|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62|0-2": {
+        "Ethernet128|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|0-2": {
+        "Ethernet148|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74|0-2": {
+        "Ethernet220|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|0-2": {
+        "Ethernet144|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78|0-2": {
+        "Ethernet160|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80|0-2": {
+        "Ethernet140|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82|0-2": {
+        "Ethernet164|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84|0-2": {
+        "Ethernet196|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86|0-2": {
+        "Ethernet192|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|0-2": {
+        "Ethernet200|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|0-2": {
+        "Ethernet168|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|0-2": {
+        "Ethernet152|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|0-2": {
+        "Ethernet136|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|0-2": {
+        "Ethernet156|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106|0-2": {
+        "Ethernet204|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|0-2": {
+        "Ethernet132|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110|0-2": {
+        "Ethernet172|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112|0-2": {
+        "Ethernet216|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet114|0-2": {
+        "Ethernet176|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116|0-2": {
+        "Ethernet212|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet118|0-2": {
+        "Ethernet208|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet120|0-2": {
+        "Ethernet180|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet122|0-2": {
+        "Ethernet184|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet124|0-2": {
+        "Ethernet188|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet126|0-2": {
+        "Ethernet128|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet0|5-6": {
+        "Ethernet148|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58|5-6": {
+        "Ethernet220|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|5-6": {
+        "Ethernet144|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62|5-6": {
+        "Ethernet160|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|5-6": {
+        "Ethernet140|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74|5-6": {
+        "Ethernet164|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|5-6": {
+        "Ethernet196|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78|5-6": {
+        "Ethernet192|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80|5-6": {
+        "Ethernet200|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82|5-6": {
+        "Ethernet168|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84|5-6": {
+        "Ethernet152|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86|5-6": {
+        "Ethernet136|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|5-6": {
+        "Ethernet156|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|5-6": {
+        "Ethernet204|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|5-6": {
+        "Ethernet132|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|5-6": {
+        "Ethernet172|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|5-6": {
+        "Ethernet216|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106|5-6": {
+        "Ethernet176|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|5-6": {
+        "Ethernet212|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet112|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet114|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet116|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet118|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet120|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet122|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet124|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet126|5-6": {
+        "Ethernet208|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
@@ -1,0 +1,987 @@
+
+
+{
+    "CABLE_LENGTH": {
+        "AZURE": {
+            "Ethernet8": "5m",
+            "Ethernet2": "5m",
+            "Ethernet0": "5m",
+            "Ethernet6": "5m",
+            "Ethernet4": "5m",
+            "Ethernet108": "5m",
+            "Ethernet100": "5m",
+            "Ethernet104": "5m",
+            "Ethernet106": "5m",
+            "Ethernet58": "5m",
+            "Ethernet126": "5m",
+            "Ethernet96": "5m",
+            "Ethernet124": "5m",
+            "Ethernet122": "5m",
+            "Ethernet92": "5m",
+            "Ethernet120": "5m",
+            "Ethernet50": "5m",
+            "Ethernet52": "5m",
+            "Ethernet54": "5m",
+            "Ethernet56": "5m",
+            "Ethernet76": "5m",
+            "Ethernet74": "5m",
+            "Ethernet18": "5m",
+            "Ethernet70": "40m",
+            "Ethernet32": "5m",
+            "Ethernet72": "5m",
+            "Ethernet16": "5m",
+            "Ethernet36": "5m",
+            "Ethernet78": "5m",
+            "Ethernet60": "5m",
+            "Ethernet28": "5m",
+            "Ethernet62": "5m",
+            "Ethernet14": "5m",
+            "Ethernet88": "5m",
+            "Ethernet118": "5m",
+            "Ethernet24": "5m",
+            "Ethernet116": "5m",
+            "Ethernet82": "5m",
+            "Ethernet114": "5m",
+            "Ethernet80": "5m",
+            "Ethernet112": "5m",
+            "Ethernet86": "5m",
+            "Ethernet110": "5m",
+            "Ethernet84": "5m",
+            "Ethernet48": "5m",
+            "Ethernet10": "5m",
+            "Ethernet44": "5m",
+            "Ethernet42": "5m",
+            "Ethernet40": "5m",
+            "Ethernet64": "40m",
+            "Ethernet66": "40m",
+            "Ethernet12": "5m",
+            "Ethernet46": "5m",
+            "Ethernet20": "5m",
+            "Ethernet22": "5m",
+            "Ethernet68": "40m"
+        }
+    },
+
+    "BUFFER_POOL": {
+        "ingress_zero_pool" : {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        "ingress_lossless_pool": {
+            "size": "7719936",
+            "xoff": "1032192",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "13945824",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "7719936",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_pg_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_zero_pool]",
+          "size":"0",
+          "static_th":"0"
+        },
+        "ingress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossy_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+        "Ethernet8": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet2": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet6": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet4": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet50": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet52": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet54": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet56": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet18": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet70": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet14": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet10": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet44": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet42": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet66": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet12": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet46": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet20": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet22": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        }
+,
+        "Ethernet0": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet106": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet58": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet126": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet124": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet122": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet74": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet78": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet62": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet118": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet82": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet114": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet86": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet110": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        }
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+        "Ethernet8": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet2": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet6": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet4": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet50": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet52": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet54": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet56": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet18": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet70": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet14": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet10": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet44": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet42": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet66": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet12": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet46": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet20": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet22": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }
+,
+        "Ethernet0": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet106": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet58": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet126": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet124": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet122": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet74": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet78": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet62": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet118": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet82": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet114": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet86": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet110": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }
+    },
+    "BUFFER_PG": {
+        "Ethernet8|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet2|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet6|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet4|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet50|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet52|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet54|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet56|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet18|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet70|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet32|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet16|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet36|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet28|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet14|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet24|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet48|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet10|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet44|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet42|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet40|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet64|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet66|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet12|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet46|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet20|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet22|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet68|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        }
+,       "Ethernet0|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet108|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet100|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet104|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet106|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet58|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet126|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet96|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet124|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet122|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet92|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet120|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet76|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet74|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet72|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet78|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet60|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet62|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet88|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet118|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet116|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet82|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet114|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet80|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet112|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet86|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet110|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet84|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        }
+    },
+
+    "BUFFER_QUEUE": {
+        "Ethernet8|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet2|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet6|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet4|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet50|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet52|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet54|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet56|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet18|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet70|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet32|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet16|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet36|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet28|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet14|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet24|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet48|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet10|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet44|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet42|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet40|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet64|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet66|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet12|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet46|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet20|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet22|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet68|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet8|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet2|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet6|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet4|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet50|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet52|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet54|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet56|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet18|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet70|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet32|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet14|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet24|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet10|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet44|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet42|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet40|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet64|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet66|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet46|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet22|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet68|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet8|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet2|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet6|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet4|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet50|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet52|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet54|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet56|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet18|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet70|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet32|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet14|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet24|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet10|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet44|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet42|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet40|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet64|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet66|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet46|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet22|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet68|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }
+,
+        "Ethernet0|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet108|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet100|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet104|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet106|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet58|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet126|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet96|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet124|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet122|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet92|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet120|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet76|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet74|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet72|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet78|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet60|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet62|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet88|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet118|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet116|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet82|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet114|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet80|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet112|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet86|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet110|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet84|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffers-mellanox2700.json
@@ -899,88 +899,256 @@
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
 ,
-        "Ethernet0|0-7": {
+        "Ethernet0|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet108|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet100|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet104|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet106|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet58|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet126|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet96|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet124|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet122|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet92|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet120|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet76|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet74|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet72|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet78|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet60|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet62|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet88|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet118|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet116|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet82|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet114|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet80|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet112|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet86|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet110|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet84|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
+        },
+        "Ethernet0|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|0-7": {
+        "Ethernet108|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|0-7": {
+        "Ethernet100|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|0-7": {
+        "Ethernet104|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106|0-7": {
+        "Ethernet106|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58|0-7": {
+        "Ethernet58|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet126|0-7": {
+        "Ethernet126|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|0-7": {
+        "Ethernet96|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet124|0-7": {
+        "Ethernet124|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet122|0-7": {
+        "Ethernet122|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|0-7": {
+        "Ethernet92|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet120|0-7": {
+        "Ethernet120|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|0-7": {
+        "Ethernet76|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74|0-7": {
+        "Ethernet74|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|0-7": {
+        "Ethernet72|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78|0-7": {
+        "Ethernet78|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|0-7": {
+        "Ethernet60|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62|0-7": {
+        "Ethernet62|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|0-7": {
+        "Ethernet88|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet118|0-7": {
+        "Ethernet118|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116|0-7": {
+        "Ethernet116|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82|0-7": {
+        "Ethernet82|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet114|0-7": {
+        "Ethernet114|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80|0-7": {
+        "Ethernet80|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112|0-7": {
+        "Ethernet112|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86|0-7": {
+        "Ethernet86|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110|0-7": {
+        "Ethernet110|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84|0-7": {
+        "Ethernet84|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet0|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet108|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet100|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet104|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet106|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet58|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet126|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet96|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet124|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet122|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet92|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet120|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet76|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet74|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet72|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet78|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet60|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet62|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet88|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet118|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet116|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet82|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet114|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet80|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet112|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet86|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet110|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet84|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-dell6100.json
@@ -1,4 +1,5 @@
 
+
 {
     "CABLE_LENGTH": {
         "AZURE": {
@@ -117,18 +118,6 @@
         "Ethernet5|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet16|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet17|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet20|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet21|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet6|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
@@ -159,28 +148,16 @@
         "Ethernet15|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet32|0": {
+        "Ethernet16|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet36|0": {
+        "Ethernet17|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet37|0": {
+        "Ethernet20|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet38|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet39|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet40|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet41|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet42|0": {
+        "Ethernet21|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet22|0": {
@@ -211,6 +188,30 @@
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet31|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet32|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet36|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet37|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet38|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet39|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet40|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet41|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet42|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet48|0": {
@@ -252,18 +253,6 @@
         "Ethernet5|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet16|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet17|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet21|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet6|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
@@ -294,28 +283,16 @@
         "Ethernet15|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet32|3-4": {
+        "Ethernet16|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet36|3-4": {
+        "Ethernet17|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet37|3-4": {
+        "Ethernet20|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet38|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet39|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet40|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet41|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet42|3-4": {
+        "Ethernet21|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet22|3-4": {
@@ -346,6 +323,30 @@
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet31|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet32|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet36|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet37|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet38|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet39|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet40|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet41|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet42|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet48|3-4": {
@@ -384,18 +385,6 @@
         "Ethernet5|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet16|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet17|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet21|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet6|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -426,28 +415,16 @@
         "Ethernet15|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet32|0-2": {
+        "Ethernet16|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet36|0-2": {
+        "Ethernet17|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet37|0-2": {
+        "Ethernet20|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet38|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet39|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet40|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet41|0-2": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet42|0-2": {
+        "Ethernet21|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet22|0-2": {
@@ -478,6 +455,30 @@
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet31|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet32|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet36|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet37|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet38|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet39|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet40|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet41|0-2": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet42|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet48|0-2": {
@@ -516,18 +517,6 @@
         "Ethernet5|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet16|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet17|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet21|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet6|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
@@ -558,28 +547,16 @@
         "Ethernet15|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet32|5-6": {
+        "Ethernet16|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet36|5-6": {
+        "Ethernet17|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet37|5-6": {
+        "Ethernet20|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet38|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet39|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet40|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet41|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet42|5-6": {
+        "Ethernet21|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet22|5-6": {
@@ -610,6 +587,30 @@
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet31|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet32|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet36|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet37|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet38|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet39|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet40|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet41|5-6": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet42|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet48|5-6": {

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2410.json
@@ -3,62 +3,62 @@
 {
     "CABLE_LENGTH": {
         "AZURE": {
-            "Ethernet0": "5m",
-            "Ethernet2": "5m",
-            "Ethernet4": "5m",
-            "Ethernet6": "5m",
-            "Ethernet8": "5m",
-            "Ethernet10": "5m",
-            "Ethernet12": "5m",
-            "Ethernet14": "5m",
-            "Ethernet16": "5m",
-            "Ethernet18": "5m",
-            "Ethernet20": "5m",
-            "Ethernet22": "5m",
-            "Ethernet24": "5m",
-            "Ethernet28": "5m",
-            "Ethernet32": "5m",
-            "Ethernet36": "5m",
-            "Ethernet40": "5m",
-            "Ethernet42": "5m",
-            "Ethernet44": "5m",
-            "Ethernet46": "5m",
-            "Ethernet48": "5m",
-            "Ethernet50": "5m",
-            "Ethernet52": "5m",
-            "Ethernet54": "5m",
-            "Ethernet56": "5m",
-            "Ethernet58": "5m",
-            "Ethernet60": "5m",
-            "Ethernet62": "5m",
+            "Ethernet0": "300m",
+            "Ethernet4": "300m",
+            "Ethernet8": "300m",
+            "Ethernet12": "300m",
+            "Ethernet16": "300m",
+            "Ethernet20": "300m",
+            "Ethernet24": "300m",
+            "Ethernet28": "300m",
+            "Ethernet32": "300m",
+            "Ethernet36": "300m",
+            "Ethernet40": "300m",
+            "Ethernet44": "300m",
+            "Ethernet48": "300m",
+            "Ethernet52": "300m",
+            "Ethernet56": "300m",
+            "Ethernet60": "300m",
             "Ethernet64": "40m",
-            "Ethernet66": "40m",
             "Ethernet68": "40m",
-            "Ethernet70": "40m",
-            "Ethernet72": "5m",
-            "Ethernet74": "5m",
-            "Ethernet76": "5m",
-            "Ethernet78": "5m",
-            "Ethernet80": "5m",
-            "Ethernet82": "5m",
-            "Ethernet84": "5m",
-            "Ethernet86": "5m",
-            "Ethernet88": "5m",
-            "Ethernet92": "5m",
-            "Ethernet96": "5m",
-            "Ethernet100": "5m",
-            "Ethernet104": "5m",
-            "Ethernet106": "5m",
-            "Ethernet108": "5m",
-            "Ethernet110": "5m",
-            "Ethernet112": "5m",
-            "Ethernet114": "5m",
-            "Ethernet116": "5m",
-            "Ethernet118": "5m",
-            "Ethernet120": "5m",
-            "Ethernet122": "5m",
-            "Ethernet124": "5m",
-            "Ethernet126": "5m"
+            "Ethernet72": "40m",
+            "Ethernet76": "40m",
+            "Ethernet80": "40m",
+            "Ethernet84": "40m",
+            "Ethernet88": "40m",
+            "Ethernet92": "40m",
+            "Ethernet96": "40m",
+            "Ethernet100": "40m",
+            "Ethernet104": "40m",
+            "Ethernet108": "40m",
+            "Ethernet112": "40m",
+            "Ethernet116": "40m",
+            "Ethernet120": "40m",
+            "Ethernet124": "40m",
+            "Ethernet128": "5m",
+            "Ethernet132": "5m",
+            "Ethernet136": "5m",
+            "Ethernet140": "5m",
+            "Ethernet144": "5m",
+            "Ethernet148": "5m",
+            "Ethernet152": "5m",
+            "Ethernet156": "5m",
+            "Ethernet160": "5m",
+            "Ethernet164": "5m",
+            "Ethernet168": "5m",
+            "Ethernet172": "5m",
+            "Ethernet176": "5m",
+            "Ethernet180": "5m",
+            "Ethernet184": "5m",
+            "Ethernet188": "5m",
+            "Ethernet192": "5m",
+            "Ethernet196": "5m",
+            "Ethernet200": "5m",
+            "Ethernet204": "5m",
+            "Ethernet208": "5m",
+            "Ethernet212": "5m",
+            "Ethernet216": "5m",
+            "Ethernet220": "5m"
         }
     },
 
@@ -69,8 +69,12 @@
             "size": "0"
         },
         "ingress_lossless_pool": {
-            "size": "7719936",
-            "xoff": "1032192",
+            "size": "3302912",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "ingress_lossy_pool": {
+            "size": "3302912",
             "type": "ingress",
             "mode": "dynamic"
         },
@@ -80,7 +84,7 @@
             "mode": "dynamic"
         },
         "egress_lossy_pool": {
-            "size": "7719936",
+            "size": "3302912",
             "type": "egress",
             "mode": "dynamic"
         }
@@ -93,6 +97,11 @@
         },
         "ingress_lossless_zero_profile" : {
           "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossy_pool]",
           "size":"0",
           "dynamic_th":"-8"
         },
@@ -112,7 +121,7 @@
             "dynamic_th":"7"
         },
         "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "pool":"[BUFFER_POOL|ingress_lossy_pool]",
             "size":"0",
             "dynamic_th":"3"
         },
@@ -133,208 +142,193 @@
         }
     },
     "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-        "Ethernet2": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        "Ethernet0": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet4": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet6": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet8": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet10": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet12": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet14": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet16": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet18": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet20": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet22": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet24": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet28": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet32": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet36": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet40": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet42": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet44": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet46": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet48": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet50": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet52": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet54": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet56": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet64": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet66": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet68": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        },
-        "Ethernet70": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }
-,
-        "Ethernet0": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet58": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet60": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet62": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet72": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet74": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet76": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet78": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet80": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet82": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet84": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet86": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet88": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet92": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet96": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet100": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet104": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet106": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet108": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet110": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet112": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet114": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet116": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet118": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet120": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
-        },
-        "Ethernet122": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile],[BUFFER_PROFILE|ingress_lossy_profile]"
+        }
+,
+        "Ethernet128": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
         },
-        "Ethernet126": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        "Ethernet132": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet136": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet140": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet144": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet148": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet152": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet156": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet160": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet164": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet168": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet172": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet176": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet180": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet184": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet188": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet192": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet196": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet200": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet204": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet208": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet212": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet216": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
+        },
+        "Ethernet220": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile],[BUFFER_PROFILE|ingress_lossy_zero_profile]"
         }
     },
     "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-        "Ethernet2": {
+        "Ethernet0": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet4": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet6": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet8": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet10": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet12": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet14": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet16": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet18": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet20": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet22": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet24": {
@@ -352,160 +346,160 @@
         "Ethernet40": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet42": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet44": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet46": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet48": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet50": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
         "Ethernet52": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        },
-        "Ethernet54": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet56": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet64": {
+        "Ethernet60": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet66": {
+        "Ethernet64": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
         "Ethernet68": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         },
-        "Ethernet70": {
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet124": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
         }
 ,
-        "Ethernet0": {
+        "Ethernet128": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58": {
+        "Ethernet132": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60": {
+        "Ethernet136": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62": {
+        "Ethernet140": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72": {
+        "Ethernet144": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74": {
+        "Ethernet148": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76": {
+        "Ethernet152": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78": {
+        "Ethernet156": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80": {
+        "Ethernet160": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82": {
+        "Ethernet164": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84": {
+        "Ethernet168": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86": {
+        "Ethernet172": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88": {
+        "Ethernet176": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92": {
+        "Ethernet180": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96": {
+        "Ethernet184": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100": {
+        "Ethernet188": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104": {
+        "Ethernet192": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106": {
+        "Ethernet196": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108": {
+        "Ethernet200": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110": {
+        "Ethernet204": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112": {
+        "Ethernet208": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet114": {
+        "Ethernet212": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116": {
+        "Ethernet216": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet118": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet120": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet122": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet124": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet126": {
+        "Ethernet220": {
             "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     },
     "BUFFER_PG": {
-        "Ethernet2|0": {
+        "Ethernet0|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet4|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet6|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet8|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet10|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet12|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet14|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet16|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet18|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet20|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet22|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet24|0": {
@@ -523,160 +517,160 @@
         "Ethernet40|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet42|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet44|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet46|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet48|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet50|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
         "Ethernet52|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
-        },
-        "Ethernet54|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet56|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet64|0": {
+        "Ethernet60|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet66|0": {
+        "Ethernet64|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
         "Ethernet68|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         },
-        "Ethernet70|0": {
+        "Ethernet72|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet76|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet80|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet84|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet88|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet92|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet96|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet100|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet104|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet108|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet112|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet116|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet120|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet124|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
         }
-,       "Ethernet0|0": {
+,       "Ethernet128|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet58|0": {
+       "Ethernet132|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet60|0": {
+       "Ethernet136|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet62|0": {
+       "Ethernet140|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet72|0": {
+       "Ethernet144|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet74|0": {
+       "Ethernet148|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet76|0": {
+       "Ethernet152|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet78|0": {
+       "Ethernet156|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet80|0": {
+       "Ethernet160|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet82|0": {
+       "Ethernet164|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet84|0": {
+       "Ethernet168|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet86|0": {
+       "Ethernet172|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet88|0": {
+       "Ethernet176|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet92|0": {
+       "Ethernet180|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet96|0": {
+       "Ethernet184|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet100|0": {
+       "Ethernet188|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet104|0": {
+       "Ethernet192|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet106|0": {
+       "Ethernet196|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet108|0": {
+       "Ethernet200|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet110|0": {
+       "Ethernet204|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet112|0": {
+       "Ethernet208|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet114|0": {
+       "Ethernet212|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet116|0": {
+       "Ethernet216|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         },
-       "Ethernet118|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet120|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet122|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet124|0": {
-            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
-        },
-       "Ethernet126|0": {
+       "Ethernet220|0": {
             "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
         }
     },
 
     "BUFFER_QUEUE": {
-        "Ethernet2|3-4": {
+        "Ethernet0|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet4|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet6|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet8|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet10|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet12|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet14|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet16|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet18|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet20|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet22|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet24|3-4": {
@@ -694,73 +688,85 @@
         "Ethernet40|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet42|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet44|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet46|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet48|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet50|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
         "Ethernet52|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-        "Ethernet54|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet56|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet64|3-4": {
+        "Ethernet60|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet66|3-4": {
+        "Ethernet64|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
         "Ethernet68|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet70|3-4": {
+        "Ethernet72|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
         },
-        "Ethernet2|0-2": {
+        "Ethernet76|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet80|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet84|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet88|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet92|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet96|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet100|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet104|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet108|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet112|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet116|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet120|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet124|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet0|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet4|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet6|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet8|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet10|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet12|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet14|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet16|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet18|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet20|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet22|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet24|0-2": {
@@ -778,73 +784,85 @@
         "Ethernet40|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet42|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet44|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet46|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet48|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet50|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet52|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet54|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet56|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet64|0-2": {
+        "Ethernet60|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet66|0-2": {
+        "Ethernet64|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet68|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet70|0-2": {
+        "Ethernet72|0-2": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet2|5-6": {
+        "Ethernet76|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet80|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet84|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet88|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet92|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet96|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet100|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet104|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet108|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet112|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet116|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet120|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet124|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet0|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet4|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet6|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet8|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet10|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet12|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet14|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet16|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet18|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet20|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet22|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet24|5-6": {
@@ -862,293 +880,284 @@
         "Ethernet40|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet42|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet44|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet46|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet48|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet50|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
         "Ethernet52|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-        "Ethernet54|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet56|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet64|5-6": {
+        "Ethernet60|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet66|5-6": {
+        "Ethernet64|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
         "Ethernet68|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         },
-        "Ethernet70|5-6": {
+        "Ethernet72|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet76|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet80|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet84|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet88|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet92|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet96|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet100|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet104|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet108|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet112|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet116|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet120|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet124|5-6": {
             "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
         }
 ,
-        "Ethernet0|3-4": {
+        "Ethernet128|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet58|3-4": {
+        "Ethernet132|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet60|3-4": {
+        "Ethernet136|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet62|3-4": {
+        "Ethernet140|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet72|3-4": {
+        "Ethernet144|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet74|3-4": {
+        "Ethernet148|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet76|3-4": {
+        "Ethernet152|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet78|3-4": {
+        "Ethernet156|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet80|3-4": {
+        "Ethernet160|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet82|3-4": {
+        "Ethernet164|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet84|3-4": {
+        "Ethernet168|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet86|3-4": {
+        "Ethernet172|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet88|3-4": {
+        "Ethernet176|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet92|3-4": {
+        "Ethernet180|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet96|3-4": {
+        "Ethernet184|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet100|3-4": {
+        "Ethernet188|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet104|3-4": {
+        "Ethernet192|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet106|3-4": {
+        "Ethernet196|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet108|3-4": {
+        "Ethernet200|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet110|3-4": {
+        "Ethernet204|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet112|3-4": {
+        "Ethernet208|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet114|3-4": {
+        "Ethernet212|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet116|3-4": {
+        "Ethernet216|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet118|3-4": {
+        "Ethernet220|3-4": {
             "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
         },
-        "Ethernet120|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet122|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet124|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet126|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_zero_profile]"
-        },
-        "Ethernet0|0-2": {
+        "Ethernet128|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58|0-2": {
+        "Ethernet132|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|0-2": {
+        "Ethernet136|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62|0-2": {
+        "Ethernet140|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|0-2": {
+        "Ethernet144|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74|0-2": {
+        "Ethernet148|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|0-2": {
+        "Ethernet152|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78|0-2": {
+        "Ethernet156|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80|0-2": {
+        "Ethernet160|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82|0-2": {
+        "Ethernet164|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84|0-2": {
+        "Ethernet168|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86|0-2": {
+        "Ethernet172|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|0-2": {
+        "Ethernet176|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|0-2": {
+        "Ethernet180|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|0-2": {
+        "Ethernet184|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|0-2": {
+        "Ethernet188|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|0-2": {
+        "Ethernet192|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106|0-2": {
+        "Ethernet196|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|0-2": {
+        "Ethernet200|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110|0-2": {
+        "Ethernet204|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet112|0-2": {
+        "Ethernet208|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet114|0-2": {
+        "Ethernet212|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet116|0-2": {
+        "Ethernet216|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet118|0-2": {
+        "Ethernet220|0-2": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet120|0-2": {
+        "Ethernet128|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet122|0-2": {
+        "Ethernet132|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet124|0-2": {
+        "Ethernet136|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet126|0-2": {
+        "Ethernet140|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet0|5-6": {
+        "Ethernet144|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet58|5-6": {
+        "Ethernet148|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet60|5-6": {
+        "Ethernet152|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet62|5-6": {
+        "Ethernet156|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet72|5-6": {
+        "Ethernet160|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet74|5-6": {
+        "Ethernet164|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet76|5-6": {
+        "Ethernet168|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet78|5-6": {
+        "Ethernet172|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet80|5-6": {
+        "Ethernet176|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet82|5-6": {
+        "Ethernet180|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet84|5-6": {
+        "Ethernet184|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet86|5-6": {
+        "Ethernet188|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet88|5-6": {
+        "Ethernet192|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet92|5-6": {
+        "Ethernet196|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet96|5-6": {
+        "Ethernet200|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet100|5-6": {
+        "Ethernet204|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet104|5-6": {
+        "Ethernet208|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet106|5-6": {
+        "Ethernet212|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet108|5-6": {
+        "Ethernet216|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         },
-        "Ethernet110|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet112|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet114|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet116|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet118|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet120|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet122|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet124|5-6": {
-            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
-        },
-        "Ethernet126|5-6": {
+        "Ethernet220|5-6": {
             "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffers-mellanox2700.json
@@ -1,0 +1,987 @@
+
+
+{
+    "CABLE_LENGTH": {
+        "AZURE": {
+            "Ethernet0": "5m",
+            "Ethernet2": "5m",
+            "Ethernet4": "5m",
+            "Ethernet6": "5m",
+            "Ethernet8": "5m",
+            "Ethernet10": "5m",
+            "Ethernet12": "5m",
+            "Ethernet14": "5m",
+            "Ethernet16": "5m",
+            "Ethernet18": "5m",
+            "Ethernet20": "5m",
+            "Ethernet22": "5m",
+            "Ethernet24": "5m",
+            "Ethernet28": "5m",
+            "Ethernet32": "5m",
+            "Ethernet36": "5m",
+            "Ethernet40": "5m",
+            "Ethernet42": "5m",
+            "Ethernet44": "5m",
+            "Ethernet46": "5m",
+            "Ethernet48": "5m",
+            "Ethernet50": "5m",
+            "Ethernet52": "5m",
+            "Ethernet54": "5m",
+            "Ethernet56": "5m",
+            "Ethernet58": "5m",
+            "Ethernet60": "5m",
+            "Ethernet62": "5m",
+            "Ethernet64": "40m",
+            "Ethernet66": "40m",
+            "Ethernet68": "40m",
+            "Ethernet70": "40m",
+            "Ethernet72": "5m",
+            "Ethernet74": "5m",
+            "Ethernet76": "5m",
+            "Ethernet78": "5m",
+            "Ethernet80": "5m",
+            "Ethernet82": "5m",
+            "Ethernet84": "5m",
+            "Ethernet86": "5m",
+            "Ethernet88": "5m",
+            "Ethernet92": "5m",
+            "Ethernet96": "5m",
+            "Ethernet100": "5m",
+            "Ethernet104": "5m",
+            "Ethernet106": "5m",
+            "Ethernet108": "5m",
+            "Ethernet110": "5m",
+            "Ethernet112": "5m",
+            "Ethernet114": "5m",
+            "Ethernet116": "5m",
+            "Ethernet118": "5m",
+            "Ethernet120": "5m",
+            "Ethernet122": "5m",
+            "Ethernet124": "5m",
+            "Ethernet126": "5m"
+        }
+    },
+
+    "BUFFER_POOL": {
+        "ingress_zero_pool" : {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        "ingress_lossless_pool": {
+            "size": "7719936",
+            "xoff": "1032192",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "13945824",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            "size": "7719936",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_pg_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_zero_pool]",
+          "size":"0",
+          "static_th":"0"
+        },
+        "ingress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossless_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossless_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossy_zero_profile" : {
+          "pool":"[BUFFER_POOL|egress_lossy_pool]",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "ingress_lossless_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "egress_lossless_profile": {
+            "pool":"[BUFFER_POOL|egress_lossless_pool]",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "q_lossy_profile": {
+            "pool":"[BUFFER_POOL|egress_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        }
+    },
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+        "Ethernet2": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet4": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet6": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet8": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet10": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet12": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet14": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet18": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet20": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet22": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet42": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet44": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet46": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet50": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet52": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet54": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet56": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet66": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        },
+        "Ethernet70": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
+        }
+,
+        "Ethernet0": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet58": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet62": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet74": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet78": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet82": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet86": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet106": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet110": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet114": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet118": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet122": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet124": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        },
+        "Ethernet126": {
+            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_zero_profile]"
+        }
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+        "Ethernet2": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet4": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet6": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet8": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet10": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet12": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet14": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet16": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet18": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet20": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet22": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet24": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet28": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet32": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet36": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet40": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet42": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet44": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet46": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet48": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet50": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet52": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet54": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet56": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet64": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet66": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet68": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        },
+        "Ethernet70": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
+        }
+,
+        "Ethernet0": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet58": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet60": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet62": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet72": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet74": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet76": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet78": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet80": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet82": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet84": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet86": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet88": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet92": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet96": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet100": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet104": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet106": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet108": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet110": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet112": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet114": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet116": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet118": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet120": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet122": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet124": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet126": {
+            "profile_list" : "[BUFFER_PROFILE|egress_lossless_zero_profile],[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }
+    },
+    "BUFFER_PG": {
+        "Ethernet2|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet4|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet6|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet8|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet10|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet12|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet14|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet16|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet18|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet20|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet22|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet24|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet28|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet32|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet36|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet40|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet42|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet44|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet46|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet48|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet50|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet52|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet54|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet56|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet64|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet66|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet68|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        },
+        "Ethernet70|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_profile]"
+        }
+,       "Ethernet0|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet58|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet60|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet62|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet72|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet74|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet76|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet78|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet80|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet82|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet84|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet86|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet88|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet92|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet96|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet100|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet104|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet106|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet108|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet110|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet112|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet114|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet116|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet118|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet120|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet122|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet124|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        },
+       "Ethernet126|0": {
+            "profile" : "[BUFFER_PROFILE|ingress_lossy_pg_zero_profile]"
+        }
+    },
+
+    "BUFFER_QUEUE": {
+        "Ethernet2|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet4|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet6|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet8|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet10|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet12|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet14|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet16|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet18|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet20|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet22|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet24|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet28|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet32|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet36|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet40|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet42|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet44|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet46|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet48|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet50|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet52|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet54|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet56|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet64|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet66|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet68|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet70|3-4": {
+            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
+        },
+        "Ethernet2|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet4|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet6|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet8|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet10|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet14|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet18|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet22|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet24|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet32|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet40|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet42|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet44|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet46|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet50|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet52|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet54|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet56|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet64|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet66|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet68|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet70|0-2": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet2|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet4|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet6|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet8|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet10|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet12|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet14|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet16|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet18|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet20|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet22|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet24|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet28|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet32|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet36|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet40|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet42|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet44|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet46|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet48|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet50|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet52|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet54|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet56|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet64|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet66|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet68|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        },
+        "Ethernet70|5-6": {
+            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
+        }
+,
+        "Ethernet0|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet58|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet60|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet62|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet72|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet74|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet76|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet78|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet80|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet82|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet84|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet86|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet88|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet92|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet96|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet100|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet104|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet106|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet108|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet110|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet112|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet114|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet116|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet118|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet120|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet122|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet124|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        },
+        "Ethernet126|0-7": {
+            "profile" : "[BUFFER_PROFILE|egress_lossy_zero_profile]"
+        }
+    }
+}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -244,7 +244,7 @@ class TestJ2Files(TestCase):
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_buffers_mellanox2700_render_template(self):
-        # Mellanox buffer template rendering for single ingress pool mode 
+        # Mellanox buffer template rendering for single ingress pool mode
         mellanox_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'mellanox', 'x86_64-mlnx_msn2700-r0', 'Mellanox-SN2700-D48C8')
         buffers_file = os.path.join(mellanox_dir_path, 'buffers.json.j2')
         port_config_ini_file = os.path.join(mellanox_dir_path, 'port_config.ini')
@@ -264,7 +264,7 @@ class TestJ2Files(TestCase):
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_buffers_mellanox2410_render_template(self):
-        # Mellanox buffer template rendering for double ingress pools mode 
+        # Mellanox buffer template rendering for double ingress pools mode
         mellanox_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'mellanox', 'x86_64-mlnx_msn2410-r0', 'ACS-MSN2410')
         buffers_file = os.path.join(mellanox_dir_path, 'buffers.json.j2')
         port_config_ini_file = os.path.join(mellanox_dir_path, 'port_config.ini')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -22,6 +22,7 @@ class TestJ2Files(TestCase):
         self.t1_mlnx_minigraph = os.path.join(self.test_dir, 't1-sample-graph-mlnx.xml')
         self.mlnx_port_config = os.path.join(self.test_dir, 'sample-port-config-mlnx.ini')
         self.dell6100_t0_minigraph = os.path.join(self.test_dir, 'sample-dell-6100-t0-minigraph.xml')
+        self.mellanox2700_t0_minigraph = os.path.join(self.test_dir, 'sample-mellanox-2700-t0-minigraph.xml')
         self.arista7050_t0_minigraph = os.path.join(self.test_dir, 'sample-arista-7050-t0-minigraph.xml')
         self.multi_asic_minigraph = os.path.join(self.test_dir, 'multi_npu_data', 'sample-minigraph.xml')
         self.multi_asic_port_config = os.path.join(self.test_dir, 'multi_npu_data', 'sample_port_config-0.ini')
@@ -239,6 +240,25 @@ class TestJ2Files(TestCase):
         os.remove(buffers_config_file_new)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'buffers-dell6100.json')
+        assert filecmp.cmp(sample_output_file, self.output_file)
+
+    def test_buffers_mellanox2700_render_template(self):
+        mellanox_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'mellanox', 'x86_64-mlnx_msn2700-r0', 'Mellanox-SN2700-D48C8')
+        buffers_file = os.path.join(mellanox_dir_path, 'buffers.json.j2')
+        port_config_ini_file = os.path.join(mellanox_dir_path, 'port_config.ini')
+
+        # copy buffers_config.j2 to the Dell S6100 directory to have all templates in one directory
+        buffers_config_file = os.path.join(self.test_dir, '..', '..', '..', 'files', 'build_templates', 'buffers_config.j2')
+        shutil.copy2(buffers_config_file, mellanox_dir_path)
+
+        argument = '-m ' + self.mellanox2700_t0_minigraph + ' -p ' + port_config_ini_file + ' -t ' + buffers_file + ' > ' + self.output_file
+        self.run_script(argument)
+
+        # cleanup
+        buffers_config_file_new = os.path.join(mellanox_dir_path, 'buffers_config.j2')
+        os.remove(buffers_config_file_new)
+
+        sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'buffers-mellanox2700.json')
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_ipinip_multi_asic(self):

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -23,6 +23,7 @@ class TestJ2Files(TestCase):
         self.mlnx_port_config = os.path.join(self.test_dir, 'sample-port-config-mlnx.ini')
         self.dell6100_t0_minigraph = os.path.join(self.test_dir, 'sample-dell-6100-t0-minigraph.xml')
         self.mellanox2700_t0_minigraph = os.path.join(self.test_dir, 'sample-mellanox-2700-t0-minigraph.xml')
+        self.mellanox2410_t1_minigraph = os.path.join(self.test_dir, 'sample-mellanox-2410-t1-minigraph.xml')
         self.arista7050_t0_minigraph = os.path.join(self.test_dir, 'sample-arista-7050-t0-minigraph.xml')
         self.multi_asic_minigraph = os.path.join(self.test_dir, 'multi_npu_data', 'sample-minigraph.xml')
         self.multi_asic_port_config = os.path.join(self.test_dir, 'multi_npu_data', 'sample_port_config-0.ini')
@@ -243,11 +244,12 @@ class TestJ2Files(TestCase):
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_buffers_mellanox2700_render_template(self):
+        # Mellanox buffer template rendering for single ingress pool mode 
         mellanox_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'mellanox', 'x86_64-mlnx_msn2700-r0', 'Mellanox-SN2700-D48C8')
         buffers_file = os.path.join(mellanox_dir_path, 'buffers.json.j2')
         port_config_ini_file = os.path.join(mellanox_dir_path, 'port_config.ini')
 
-        # copy buffers_config.j2 to the Dell S6100 directory to have all templates in one directory
+        # copy buffers_config.j2 to the Mellanox 2700 directory to have all templates in one directory
         buffers_config_file = os.path.join(self.test_dir, '..', '..', '..', 'files', 'build_templates', 'buffers_config.j2')
         shutil.copy2(buffers_config_file, mellanox_dir_path)
 
@@ -259,6 +261,26 @@ class TestJ2Files(TestCase):
         os.remove(buffers_config_file_new)
 
         sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'buffers-mellanox2700.json')
+        assert filecmp.cmp(sample_output_file, self.output_file)
+
+    def test_buffers_mellanox2410_render_template(self):
+        # Mellanox buffer template rendering for double ingress pools mode 
+        mellanox_dir_path = os.path.join(self.test_dir, '..', '..', '..', 'device', 'mellanox', 'x86_64-mlnx_msn2410-r0', 'ACS-MSN2410')
+        buffers_file = os.path.join(mellanox_dir_path, 'buffers.json.j2')
+        port_config_ini_file = os.path.join(mellanox_dir_path, 'port_config.ini')
+
+        # copy buffers_config.j2 to the Mellanox 2410 directory to have all templates in one directory
+        buffers_config_file = os.path.join(self.test_dir, '..', '..', '..', 'files', 'build_templates', 'buffers_config.j2')
+        shutil.copy2(buffers_config_file, mellanox_dir_path)
+
+        argument = '-m ' + self.mellanox2410_t1_minigraph + ' -p ' + port_config_ini_file + ' -t ' + buffers_file + ' > ' + self.output_file
+        self.run_script(argument)
+
+        # cleanup
+        buffers_config_file_new = os.path.join(mellanox_dir_path, 'buffers_config.j2')
+        os.remove(buffers_config_file_new)
+
+        sample_output_file = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'buffers-mellanox2410.json')
         assert filecmp.cmp(sample_output_file, self.output_file)
 
     def test_ipinip_multi_asic(self):


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support zero buffer profiles
1. Add buffer profiles and pool definition for zero buffer profiles
2. Support applying zero profiles on `INACTIVE PORTS`
3. Enable `dynamic buffer manager` to load zero pools and profiles from a JSON file

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it
1. Add buffer profiles and pool definition for zero buffer profiles
   - If the buffer model is static:
      - Apply normal buffer profiles to admin-up ports
      - Apply zero buffer profiles to admin-down ports
   - If the buffer model is dynamic:
      - Apply normal buffer profiles to all ports
      - buffer manager will take care when a port is shut down
2. Update `buffers_config.j2` to support `INACTIVE PORTS` by extending the existing macros to generate the various buffer objects, including PGs, queues, ingress/egress profile lists
   - Originally, all the macros to generate the above buffer objects took active ports only as an argument
   - Now that buffer items need to be generated on inactive ports as well, an extra argument representing the inactive ports need to be added
   - To be backward compatible, a new series of macros are introduced to take both active and inactive ports as arguments
   - The original version (with active ports only) will be checked first. If it is not defined, then the extended version will be called
   - Only vendors who support zero profiles need to change their buffer templates
3. Enable `buffer manager` to load zero pools and profiles from a JSON file:
   - The JSON file is provided on a per-platform basis
   - It is copied from `platform/<vendor>` folder to `/usr/share/sonic/temlates` folder in compiling time and rendered when the swss container is being created.
4. To make code clean and reduce redundant code, extract common macros from buffer_defaults_t{0,1}.j2 of all SKUs to two common files:
   - One in Mellanox-SN2700-D48C8 for single ingress pool mode
   - The other in ACS-MSN2700 for double ingress pool mode

   Those files of all other SKUs will be symbol link to the above files
5. Update `sonic-cfggen` test accordingly:
   - Adjust example output file of JSON template for unit test
   - Add unit test in for Mellanox's new buffer templates.

#### How to verify it
1. Regression test.
2. Unit test in sonic-cfggen

Run regression test and manually test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

