### PR TITLE
[CI] Extend timeout for kvm-t0 test from 300 minutes to 360 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
   - job:
     pool: sonictest
     displayName: "kvmtest-t0"
-    timeoutInMinutes: 300
+    timeoutInMinutes: 360
 
     steps:
     - template: .azure-pipelines/run-test-template.yml


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Extend timeout for kvm-t0 test from 300 minutes to 360 minutes

Recently a lot of PRs didn't pass azure pipeline kvm v0 test due to timeout

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

#### How to verify it

A dry run was run for one of the failing PRs and passed.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

