### PR TITLE
[Mellanox] Fix typo and missing file in buffer templates

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t0.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '20664320' %}
-{% set ingress_lossless_xoff_size =  '3321856' %}
+{% set ingress_lossless_pool_xoff =  '3321856' %}
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '20664320' %}
 

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/Mellanox-SN3800-D100C12S2/buffers_defaults_t1.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '19601408' %}
-{% set ingress_lossless_xoff_size =  '4384768' %}
+{% set ingress_lossless_pool_xoff =  '4384768' %}
 {% set egress_lossless_pool_size =  '34287552' %}
 {% set egress_lossy_pool_size =  '19601408' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t0.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '49905664' %}
-{% set ingress_lossless_xoff_size  =  '3702784' %}
+{% set ingress_lossless_pool_xoff  =  '3702784' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '49905664' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-C64/buffers_defaults_t1.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '48332800' %}
-{% set ingress_lossless_xoff_size  =  '5275648' %}
+{% set ingress_lossless_pool_xoff  =  '5275648' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '48332800' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_default_objects.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_default_objects.j2
@@ -1,0 +1,1 @@
+../../x86_64-mlnx_msn2700-r0/Mellanox-SN2700-D48C8/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t0.j2
@@ -17,105 +17,22 @@
 
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '44566528' %}
-{% set ingress_lossless_xoff_size = '3614720' %}
+{% set ingress_lossless_pool_xoff = '3614720' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '44566528' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D100C12S2/buffers_defaults_t1.j2
@@ -17,105 +17,24 @@
 
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '43794432' %}
-{% set ingress_lossless_xoff_size =  '4386816' %}
+{% set ingress_lossless_pool_xoff =  '4386816' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '43794432' %}
 
-{%- macro generate_port_lists(PORT_ALL) %}
-    {# Generate list of ports #}
-    {%- for port_idx in range(0, 32) %}
-        {%- if PORT_ALL.append("Ethernet%d" % (port_idx)) %}{%- endif %}
-    {%- endfor %}
+{% import 'buffers_defaults_objects.j2' as defs with context %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+{{ defs.generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_buffer_pool_and_profiles() %}
-    "BUFFER_POOL": {
-        "ingress_lossless_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ ingress_lossless_pool_size }}",
-            "xoff": "{{ ingress_lossless_xoff_size }}",
-            {%- endif %}
-            "type": "ingress",
-            "mode": "dynamic"
-        },
-        "egress_lossless_pool": {
-            "size": "{{ egress_lossless_pool_size }}",
-            "type": "egress",
-            "mode": "dynamic"
-        },
-        "egress_lossy_pool": {
-            {%- if dynamic_mode is not defined %}
-            "size": "{{ egress_lossy_pool_size }}",
-            {%- endif %}
-            "type": "egress",
-            "mode": "dynamic"
-        }
-    },
-    "BUFFER_PROFILE": {
-        "ingress_lossless_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "ingress_lossy_profile": {
-            "pool":"[BUFFER_POOL|ingress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        },
-        "egress_lossless_profile": {
-            "pool":"[BUFFER_POOL|egress_lossless_pool]",
-            "size":"0",
-            "dynamic_th":"7"
-        },
-        "egress_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"9216",
-            "dynamic_th":"7"
-        },
-        "q_lossy_profile": {
-            "pool":"[BUFFER_POOL|egress_lossy_pool]",
-            "size":"0",
-            "dynamic_th":"3"
-        }
-    },
+{%- macro generate_profile_lists_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_profile_lists(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_profile_lists(port_names) %}
-    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|ingress_lossless_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    },
-    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
-{% for port in port_names.split(',') %}
-        "{{ port }}": {
-            "profile_list" : "[BUFFER_PROFILE|egress_lossless_profile],[BUFFER_PROFILE|egress_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_queue_buffers_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_queue_buffers(port_names_active, port_names_inactive) }}
 {%- endmacro %}
 
-{%- macro generate_queue_buffers(port_names) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names.split(',') %}
-        "{{ port }}|3-4": {
-            "profile" : "[BUFFER_PROFILE|egress_lossless_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|0-2": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        },
-{% endfor %}
-{% for port in port_names.split(',') %}
-        "{{ port }}|5-6": {
-            "profile" : "[BUFFER_PROFILE|q_lossy_profile]"
-        }{% if not loop.last %},{% endif %}
-
-{% endfor %}
-    }
+{%- macro generate_pg_profiles_with_inactive_ports(port_names_active, port_names_inactive) %}
+{{ defs.generate_pg_profiles(port_names_active, port_names_inactive) }}
 {%- endmacro %}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t0.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '43827200' %}
-{% set ingress_lossless_xoff_size = '3702784' %}
+{% set ingress_lossless_pool_xoff = '3702784' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '43827200' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D112C8/buffers_defaults_t1.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '43048960' %}
-{% set ingress_lossless_xoff_size =  '4481024' %}
+{% set ingress_lossless_pool_xoff =  '4481024' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '43048960' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t0.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '47398912' %}
-{% set ingress_lossless_xoff_size = '3604480' %}
+{% set ingress_lossless_pool_xoff = '3604480' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '47398912' %}
 

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/Mellanox-SN4600C-D48C40/buffers_defaults_t1.j2
@@ -16,7 +16,7 @@
 #}
 {% set default_cable = '5m' %}
 {% set ingress_lossless_pool_size =  '46587904' %}
-{% set ingress_lossless_xoff_size = '4415488' %}
+{% set ingress_lossless_pool_xoff = '4415488' %}
 {% set egress_lossless_pool_size =  '60817392' %}
 {% set egress_lossy_pool_size =  '46587904' %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix typo and missing files in SN3800 and SN4600C's buffer templates

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### How I did it

1. ingress_lossless_xoff_size => ingress_lossless_pool_xoff
2. add missing files for SN4600C-D100C12S2

#### How to verify it

Deploy the fix and verify whether the device can be up.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

