### PR TITLE
[VS] Align threshold mode of zero buffer profile of egress_lossless_pool

### DIFF
--- a/platform/vs/docker-sonic-vs/zero_profiles.json
+++ b/platform/vs/docker-sonic-vs/zero_profiles.json
@@ -43,7 +43,7 @@
         "BUFFER_PROFILE_TABLE:egress_lossless_zero_profile" : {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "dynamic_th":"-8"
+            "static_th":"0"
         },
         "OP": "SET"
     },


### PR DESCRIPTION
On vs platform, egress_lossless_pool's mode is static.
So the corresponding profile should be of static_th as well.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

