### PR TITLE
Support PSU power thresholds

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -240,7 +240,7 @@ class Psu(FixedPsu):
         self.fan_ambient_temp = os.path.join(PSU_PATH, "thermal/fan_amb")
         self.ambient_temp_critical_threshold = os.path.join(PSU_PATH, "config/amb_tmp_crit_limit")
         self.ambient_temp_warning_threshold = os.path.join(PSU_PATH, "config/amb_tmp_warn_limit")
-        self.psu_power_slop = os.path.join(PSU_PATH, "config/psu_power_slop")
+        self.psu_power_slope = os.path.join(PSU_PATH, "config/psu_power_slope")
 
         self.psu_temp = os.path.join(PSU_PATH, 'thermal/psu{}_temp'.format(self.index))
         self.psu_temp_threshold = os.path.join(PSU_PATH, 'thermal/psu{}_temp_max'.format(self.index))
@@ -523,7 +523,7 @@ class Psu(FixedPsu):
                 if ambient_temp < temp_threshold:
                     power_threshold = power_max_capacity
                 else:
-                    slope = utils.read_int_from_file(self.psu_power_slop)
+                    slope = utils.read_int_from_file(self.psu_power_slope)
                     power_threshold = power_max_capacity - (ambient_temp - temp_threshold) * slope
                 return float(power_threshold) / 1000000
 

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -219,6 +219,8 @@ class Psu(FixedPsu):
 
     shared_led = None
 
+    psu_may_support_power_threshold = True
+
     def __init__(self, psu_index):
         super(Psu, self).__init__(psu_index)
 
@@ -253,6 +255,11 @@ class Psu(FixedPsu):
         # initialize thermal for PSU
         from .thermal import initialize_psu_thermal
         self._thermal_list = initialize_psu_thermal(psu_index, self.get_power_available_status)
+
+        # This effectively forms a logical AND operation on all PSUs existing on the system
+        # It will be true only if the file exists for all PSUs
+        if Psu.psu_may_support_power_threshold:
+            Psu.psu_may_support_power_threshold = os.path.exists(self.psu_power_max_capacity)
 
     @property
     def psu_voltage(self):
@@ -514,7 +521,7 @@ class Psu(FixedPsu):
 
     def _get_psu_power_threshold(self, temp_threshold_path):
         if self.get_powergood_status():
-            if os.path.exists(self.psu_power_max_capacity):
+            if Psu.psu_may_support_power_threshold:
                 power_max_capacity = utils.read_int_from_file(self.psu_power_max_capacity)
                 temp_threshold = utils.read_int_from_file(temp_threshold_path)
                 fan_ambient_temp = utils.read_int_from_file(self.fan_ambient_temp)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -224,8 +224,6 @@ class Psu(FixedPsu):
 
     shared_led = None
 
-    all_psus_support_power_threshold = True
-
     def __init__(self, psu_index):
         super(Psu, self).__init__(psu_index)
 
@@ -255,11 +253,6 @@ class Psu(FixedPsu):
         # initialize thermal for PSU
         from .thermal import initialize_psu_thermal
         self._thermal_list = initialize_psu_thermal(psu_index, self.get_power_available_status)
-
-        # This effectively forms a logical AND operation on all PSUs existing on the system
-        # It will be true only if the file exists for all PSUs
-        if Psu.all_psus_support_power_threshold:
-            Psu.all_psus_support_power_threshold = os.path.exists(self.psu_power_max_capacity)
 
     @property
     def psu_voltage(self):
@@ -529,7 +522,7 @@ class Psu(FixedPsu):
                 threshold = max capacity - slope*(amb_temp - ambient_temp_threshold)
         """
         if self.get_powergood_status():
-            if Psu.all_psus_support_power_threshold:
+            if os.path.exists(self.psu_power_max_capacity):
                 power_max_capacity = utils.read_int_from_file(self.psu_power_max_capacity)
                 temp_threshold = utils.read_int_from_file(temp_threshold_path)
                 fan_ambient_temp = utils.read_int_from_file(Psu.FAN_AMBIENT_TEMP)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -219,7 +219,7 @@ class Psu(FixedPsu):
 
     shared_led = None
 
-    psu_may_support_power_threshold = True
+    all_psus_support_power_threshold = True
 
     def __init__(self, psu_index):
         super(Psu, self).__init__(psu_index)
@@ -258,8 +258,8 @@ class Psu(FixedPsu):
 
         # This effectively forms a logical AND operation on all PSUs existing on the system
         # It will be true only if the file exists for all PSUs
-        if Psu.psu_may_support_power_threshold:
-            Psu.psu_may_support_power_threshold = os.path.exists(self.psu_power_max_capacity)
+        if Psu.all_psus_support_power_threshold:
+            Psu.all_psus_support_power_threshold = os.path.exists(self.psu_power_max_capacity)
 
     @property
     def psu_voltage(self):
@@ -521,7 +521,7 @@ class Psu(FixedPsu):
 
     def _get_psu_power_threshold(self, temp_threshold_path):
         if self.get_powergood_status():
-            if Psu.psu_may_support_power_threshold:
+            if Psu.all_psus_support_power_threshold:
                 power_max_capacity = utils.read_int_from_file(self.psu_power_max_capacity)
                 temp_threshold = utils.read_int_from_file(temp_threshold_path)
                 fan_ambient_temp = utils.read_int_from_file(self.fan_ambient_temp)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -532,6 +532,9 @@ class Psu(FixedPsu):
                 else:
                     slope = utils.read_int_from_file(self.psu_power_slope)
                     power_threshold = power_max_capacity - (ambient_temp - temp_threshold) * slope
+                if power_threshold <= 0:
+                    logger.log_warning('Got negative PSU power threshold {} for {}'.format(power_threshold, self.get_name()))
+                    power_threshold = 0
                 return float(power_threshold) / 1000000
 
         return None

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -540,7 +540,7 @@ class Psu(FixedPsu):
 
         return None
 
-    def get_psu_power_threshold(self):
+    def get_psu_power_warning_threshold(self):
         """
         Retrieve the warning threshold of the power on this PSU
         The value can be volatile, so the caller should call the API each time it is used.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -520,6 +520,14 @@ class Psu(FixedPsu):
         return None
 
     def _get_psu_power_threshold(self, temp_threshold_path):
+        """
+        Calculate power threshold for a PSU according to the maximum power capacity and ambient temperature
+            amb_temp = min(port_amb, fan_amb)
+            If amb_temp < ambient_temp_threshold
+                threshold = max capacity
+            else
+                threshold = max capacity - slope*(amb_temp - ambient_temp_threshold)
+        """
         if self.get_powergood_status():
             if Psu.all_psus_support_power_threshold:
                 power_max_capacity = utils.read_int_from_file(self.psu_power_max_capacity)

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -214,6 +214,5 @@ class TestPsu:
 
     def test_psu_not_support_power_threshold(self):
         psu = Psu(0)
-        assert not Psu.all_psus_support_power_threshold
         assert psu.get_psu_power_threshold() is None
         assert psu.get_psu_power_critical_threshold() is None

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -163,32 +163,32 @@ class TestPsu:
         mock_run_command.assert_called_with('sensors -s')
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
-    @mock.patch('utils.read_int_from_file')
+    @mock.patch('sonic_platform.utils.read_int_from_file')
     def test_psu_power_threshold(self, mock_read_int_from_file):
         Psu.all_psus_support_power_threshold = True
         psu = Psu(0)
         common_info = {
             psu.psu_oper_status: 1,
             psu.psu_power_max_capacity: 100000000,
-            psu.ambient_temp_critical_threshold: 65000,
-            psu.ambient_temp_warning_threshold: 55000,
-            psu.psu_power_slope: 2000
+            psu.AMBIENT_TEMP_CRITICAL_THRESHOLD: 65000,
+            psu.AMBIENT_TEMP_WARNING_THRESHOLD: 55000,
+            psu.PSU_POWER_SLOPE: 2000
             }
         normal_data = {
-            psu.port_ambient_temp: 55000,
-            psu.fan_ambient_temp: 50000,
+            psu.PORT_AMBIENT_TEMP: 55000,
+            psu.FAN_AMBIENT_TEMP: 50000,
             'warning_threshold': 100.0,
             'critical_threshold': 100.0
             }
         warning_data = {
-            psu.port_ambient_temp: 65000,
-            psu.fan_ambient_temp: 60000,
+            psu.PORT_AMBIENT_TEMP: 65000,
+            psu.FAN_AMBIENT_TEMP: 60000,
             'warning_threshold': 90.0,
             'critical_threshold': 100.0
             }
         critical_data = {
-            psu.port_ambient_temp: 70000,
-            psu.fan_ambient_temp: 75000,
+            psu.PORT_AMBIENT_TEMP: 70000,
+            psu.FAN_AMBIENT_TEMP: 75000,
             'warning_threshold': 70.0,
             'critical_threshold': 90.0
             }

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -170,7 +170,7 @@ class TestPsu:
             psu.psu_power_max_capacity: 100000000,
             psu.ambient_temp_critical_threshold: 65000,
             psu.ambient_temp_warning_threshold: 55000,
-            psu.psu_power_slop: 2000
+            psu.psu_power_slope: 2000
             }
         normal_data = {
             psu.port_ambient_temp: 55000,

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -212,5 +212,6 @@ class TestPsu:
 
     def test_psu_not_support_power_threshold(self):
         psu = Psu(0)
+        assert not psu.psu_may_support_power_threshold
         assert psu.get_psu_power_threshold() is None
         assert psu.get_psu_power_critical_threshold() is None

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -199,7 +199,7 @@ class TestPsu:
             else:
                 return test_data[value]
 
-        utils.read_int_from_file = mock.MagicMock(side_effect=mock_side_effect)
+        mock_read_int_from_file.side_effect = mock_side_effect
         test_data = normal_data
         assert psu.get_psu_power_threshold() == normal_data['warning_threshold']
         assert psu.get_psu_power_critical_threshold() == normal_data['critical_threshold']

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -161,3 +161,56 @@ class TestPsu:
         vpd_info[InvalidPsuVolWA.CAPACITY_FIELD] = InvalidPsuVolWA.EXPECT_CAPACITY
         assert InvalidPsuVolWA.run(psu, InvalidPsuVolWA.INVALID_VOLTAGE_VALUE, '') == 9999
         mock_run_command.assert_called_with('sensors -s')
+
+    @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
+    def test_psu_power_threshold(self):
+        psu = Psu(0)
+        common_info = {
+            psu.psu_oper_status: 1,
+            psu.psu_power_max_capacity: 100000000,
+            psu.ambient_temp_critical_threshold: 65000,
+            psu.ambient_temp_warning_threshold: 55000,
+            psu.psu_power_slop: 2000
+            }
+        normal_data = {
+            psu.port_ambient_temp: 55000,
+            psu.fan_ambient_temp: 50000,
+            'warning_threshold': 100.0,
+            'critical_threshold': 100.0
+            }
+        warning_data = {
+            psu.port_ambient_temp: 65000,
+            psu.fan_ambient_temp: 60000,
+            'warning_threshold': 90.0,
+            'critical_threshold': 100.0
+            }
+        critical_data = {
+            psu.port_ambient_temp: 70000,
+            psu.fan_ambient_temp: 75000,
+            'warning_threshold': 70.0,
+            'critical_threshold': 90.0
+            }
+        test_data = {}
+        def mock_side_effect(value):
+            if value in common_info:
+                return common_info[value]
+            else:
+                return test_data[value]
+
+        utils.read_int_from_file = mock.MagicMock(side_effect=mock_side_effect)
+        test_data = normal_data
+        assert psu.get_psu_power_threshold() == normal_data['warning_threshold']
+        assert psu.get_psu_power_critical_threshold() == normal_data['critical_threshold']
+
+        test_data = warning_data
+        assert psu.get_psu_power_threshold() == warning_data['warning_threshold']
+        assert psu.get_psu_power_critical_threshold() == warning_data['critical_threshold']
+
+        test_data = critical_data
+        assert psu.get_psu_power_threshold() == critical_data['warning_threshold']
+        assert psu.get_psu_power_critical_threshold() == critical_data['critical_threshold']
+
+    def test_psu_not_support_power_threshold(self):
+        psu = Psu(0)
+        assert psu.get_psu_power_threshold() is None
+        assert psu.get_psu_power_critical_threshold() is None

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -163,7 +163,8 @@ class TestPsu:
         mock_run_command.assert_called_with('sensors -s')
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
-    def test_psu_power_threshold(self):
+    @mock.patch('utils.read_int_from_file')
+    def test_psu_power_threshold(self, mock_read_int_from_file):
         Psu.all_psus_support_power_threshold = True
         psu = Psu(0)
         common_info = {

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -164,6 +164,7 @@ class TestPsu:
 
     @mock.patch('os.path.exists', mock.MagicMock(return_value=True))
     def test_psu_power_threshold(self):
+        Psu.all_psus_support_power_threshold = True
         psu = Psu(0)
         common_info = {
             psu.psu_oper_status: 1,
@@ -212,6 +213,6 @@ class TestPsu:
 
     def test_psu_not_support_power_threshold(self):
         psu = Psu(0)
-        assert not psu.psu_may_support_power_threshold
+        assert not Psu.all_psus_support_power_threshold
         assert psu.get_psu_power_threshold() is None
         assert psu.get_psu_power_critical_threshold() is None

--- a/platform/mellanox/mlnx-platform-api/tests/test_psu.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_psu.py
@@ -201,18 +201,18 @@ class TestPsu:
 
         mock_read_int_from_file.side_effect = mock_side_effect
         test_data = normal_data
-        assert psu.get_psu_power_threshold() == normal_data['warning_threshold']
+        assert psu.get_psu_power_warning_threshold() == normal_data['warning_threshold']
         assert psu.get_psu_power_critical_threshold() == normal_data['critical_threshold']
 
         test_data = warning_data
-        assert psu.get_psu_power_threshold() == warning_data['warning_threshold']
+        assert psu.get_psu_power_warning_threshold() == warning_data['warning_threshold']
         assert psu.get_psu_power_critical_threshold() == warning_data['critical_threshold']
 
         test_data = critical_data
-        assert psu.get_psu_power_threshold() == critical_data['warning_threshold']
+        assert psu.get_psu_power_warning_threshold() == critical_data['warning_threshold']
         assert psu.get_psu_power_critical_threshold() == critical_data['critical_threshold']
 
     def test_psu_not_support_power_threshold(self):
         psu = Psu(0)
-        assert psu.get_psu_power_threshold() is None
+        assert psu.get_psu_power_warning_threshold() is None
         assert psu.get_psu_power_critical_threshold() is None

--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -239,6 +239,18 @@ class HardwareChecker(HealthChecker):
                                                                                                                voltage_min_th,
                                                                                                                voltage_max_th))
                         continue
+
+            if not self._ignore_check(config.ignore_devices, 'psu', name, 'power_threshold'):
+                power_overload = data_dict.get('power_overload', None)
+                if power_overload == 'True':
+                    try:
+                        power = data_dict['power']
+                        power_critical_threshold = data_dict['power_critical_threshold']
+                        self.set_object_not_ok('PSU', name, 'power of {} ({}w) exceeds threshold ({}w)'.format(name, power, power_critical_threshold))
+                    except KeyError:
+                        self.set_object_not_ok('PSU', name, 'power of {} exceeds threshold but power or power_critical_threshold does not invalid'.format(name))
+                    continue
+
             self.set_object_ok('PSU', name)
 
     def reset(self):

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -374,7 +374,7 @@ def test_hardware_checker():
             'power_overload': 'True',
             'power': '101.0',
             'power_critical_threshold': '100.0',
-            'power_threshold': '90.0'
+            'power_warning_threshold': '90.0'
         },
         'PSU_INFO|PSU 7': {
             'presence': 'True',

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -362,6 +362,30 @@ def test_hardware_checker():
             'voltage': '10',
             'voltage_min_threshold': '12',
             'voltage_max_threshold': '15',
+        },
+        'PSU_INFO|PSU 6': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '12',
+            'voltage_max_threshold': '15',
+            'power_overload': 'True',
+            'power': '101.0',
+            'power_critical_threshold': '100.0',
+            'power_threshold': '90.0'
+        },
+        'PSU_INFO|PSU 7': {
+            'presence': 'True',
+            'status': 'True',
+            'temp': '55',
+            'temp_threshold': '100',
+            'voltage': '10',
+            'voltage_min_threshold': '12',
+            'voltage_max_threshold': '15',
+            'power_overload': 'True',
+            'power': '101.0'
         }
     })
 
@@ -399,6 +423,12 @@ def test_hardware_checker():
 
     assert 'PSU 5' in checker._info
     assert checker._info['PSU 5'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+    assert 'PSU 6' in checker._info
+    assert checker._info['PSU 6'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+    assert 'PSU 7' in checker._info
+    assert checker._info['PSU 7'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
 
 
 def test_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support PSU power thresholds on Mellanox platform
PSU power thresholds are not supported on all platforms. For platforms the power thresholds are not supported, `None` is returned.

Support checking whether PSU power exceeded the threshold in the system health daemon.

It will be split to 2 PRs when the code goes to the community. We have one for now for ci's convenience.

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

