### PR TITLE
[Mellanox] Enhance FW upgrade mechanism

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -41,7 +41,11 @@ function startplatform() {
             /usr/bin/flint -d $_MST_DEVICE --clear_semaphore
         fi
 
-        /usr/bin/mlnx-fw-upgrade.sh
+        /usr/bin/mlnx-fw-upgrade.sh -v
+        if [[ "$?" -ne "${EXIT_SUCCESS}" ]]; then
+            debug "Failed to upgrade fw. " "$?" "Restart syncd"
+            exit 1
+        fi
         /etc/init.d/sxdkernel restart
         debug "Firmware update procedure ended"
     fi

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -162,7 +162,7 @@ function WaitForDevice() {
     local -i QUERY_RETRY_COUNT_MAX="10"
     local -i QUERY_RETRY_COUNT="0"
 
-    ${MFT_DIAGNOSIS_FLAGS} ${QUERY_CMD} > /dev/null
+    ${QUERY_CMD} > /dev/null
 
     while [[ ("${QUERY_RETRY_COUNT}" -lt "${QUERY_RETRY_COUNT_MAX}") && ("$?" -ne "${EXIT_SUCCESS}") ]]; do
         sleep 1s

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -55,6 +55,7 @@ declare -rA FW_FILE_MAP=( \
 IMAGE_UPGRADE="${NO_PARAM}"
 SYSLOG_LOGGER="${NO_PARAM}"
 VERBOSE_LEVEL="${VERBOSE_MIN}"
+MFT_DIAGNOSIS_FLAGS=""
 
 function PrintHelp() {
     echo
@@ -82,6 +83,7 @@ function ParseArguments() {
             ;;
             -v|--verbose)
                 VERBOSE_LEVEL="${VERBOSE_MAX}"
+                MFT_DIAGNOSIS_FLAGS="FLASH_ACCESS_DEBUG=1 FW_COMPS_DEBUG=1"
             ;;
             -s|--syslog)
                 SYSLOG_LOGGER="${YES_PARAM}"
@@ -160,13 +162,21 @@ function WaitForDevice() {
     local -i QUERY_RETRY_COUNT_MAX="10"
     local -i QUERY_RETRY_COUNT="0"
 
-    ${QUERY_CMD} > /dev/null
+    ${MFT_DIAGNOSIS_FLAGS} ${QUERY_CMD} > /dev/null
 
     while [[ ("${QUERY_RETRY_COUNT}" -lt "${QUERY_RETRY_COUNT_MAX}") && ("$?" -ne "${EXIT_SUCCESS}") ]]; do
         sleep 1s
         ((QUERY_RETRY_COUNT++))
-        ${QUERY_CMD} > /dev/null
+        output=$(eval ${MFT_DIAGNOSIS_FLAGS} ${QUERY_CMD}) > /dev/null
     done
+
+    ERROR_CODE="$?"
+    if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        # Exit failure and print the detailed information
+        echo "$output"
+        failure_msg="${output#*Fail : }"
+        ExitFailure "FW Query command: ${QUERY_CMD} failed to wait for device with error: ${failure_msg}"
+    fi
 }
 
 function GetAsicType() {
@@ -224,7 +234,7 @@ function RunCmd() {
 
 function RunFwUpdateCmd() {
     local ERROR_CODE="${EXIT_SUCCESS}"
-    local COMMAND="${BURN_CMD} $@"
+    local COMMAND="${MFT_DIAGNOSIS_FLAGS} ${BURN_CMD} $@"
 
     if [[ "${VERBOSE_LEVEL}" -eq "${VERBOSE_MAX}" ]]; then
         output=$(eval "${COMMAND}")
@@ -234,6 +244,7 @@ function RunFwUpdateCmd() {
 
     ERROR_CODE="$?"
     if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then
+        echo "${output}"
         failure_msg="${output#*Fail : }"
         ExitFailure "FW Update command: ${COMMAND} failed with error: ${failure_msg}"
     fi


### PR DESCRIPTION
1. Enhance the diagnosis information collecting mechanism
   - If the option `-v` is fed, it will pass additional diagnosis flags to mlxfwmanager
   - Collect all the output from mlxfwmanager and print them to syslog if it fails
2. Abort syncd in case waiting for device or upgrading firmware fails

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

