### PR TITLE
[202211] Add yang model for scheduler in PORT_QOS_MAP (16244)

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1684,6 +1684,15 @@
                 "pbs": "2048",
                 "pir": "2560000",
                 "type": "STRICT"
+            },
+            "port_scheduler": {
+                "cbs": "256",
+                "cir": "1250000",
+                "meter_type": "bytes",
+                "pbs": "1024",
+                "pir": "25000000",
+                "type": "DWRR",
+                "weight": "10"
             }
 	},
 
@@ -1848,14 +1857,15 @@
         },
         "PORT_QOS_MAP": {
            "Ethernet0": {
-              "dot1p_to_tc_map" : "Dot1p_to_tc_map1",
-              "dscp_to_tc_map": "Dscp_to_tc_map1",
-	          "tc_to_queue_map": "tc_to_q_map1",
-	          "tc_to_pg_map": "tc_to_pg_map1",
-	          "pfc_to_queue_map": "pfc_prio_to_q_map1",
-	          "pfc_to_pg_map"   : "pfc_prio_to_pg_map1",
-	          "pfc_enable"      : "3,4",
-	          "pfcwd_sw_enable" : "3,4"
+               "dot1p_to_tc_map" : "Dot1p_to_tc_map1",
+               "dscp_to_tc_map": "Dscp_to_tc_map1",
+               "tc_to_queue_map": "tc_to_q_map1",
+               "tc_to_pg_map": "tc_to_pg_map1",
+               "pfc_to_queue_map": "pfc_prio_to_q_map1",
+               "pfc_to_pg_map"   : "pfc_prio_to_pg_map1",
+               "pfc_enable"      : "3,4",
+               "pfcwd_sw_enable" : "3,4",
+               "scheduler"       : "port_scheduler"
             },
             "Ethernet4": {
               "dot1p_to_tc_map" : "Dot1p_to_tc_map2",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
@@ -96,6 +96,11 @@
         "eStrKey": "LeafRef"
     },
 
+    "PORT_QOS_MAP_APPLY_NON_EXISTS_SCHEDULER": {
+        "desc": "Configure non exists scheduler on port.",
+        "eStrKey": "LeafRef"
+    },
+
     "PORT_QOS_MAP_APPLY_NON_EXISTS_PORT": {
         "desc": "Configure port qos map entry on non exists port.",
         "eStr": "Invalid value"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -657,6 +657,24 @@
                 ]
             }
         },
+
+        "sonic-scheduler:sonic-scheduler":{
+            "sonic-scheduler:SCHEDULER": {
+                "SCHEDULER_LIST": [
+                {
+                    "name":"port_scheduler",
+                    "cbs": "256",
+                    "cir": "1250000",
+                    "meter_type": "bytes",
+                    "pbs": "1024",
+                    "pir": "25000000",
+                    "type": "DWRR",
+                    "weight": "10"
+                }
+                ]
+            }
+        },
+
         "sonic-port-qos-map:sonic-port-qos-map": {
             "sonic-port-qos-map:PORT_QOS_MAP": {
                 "PORT_QOS_MAP_LIST": [
@@ -670,7 +688,8 @@
                         "dscp_to_tc_map": "map1",
                         "dot1p_to_tc_map": "map1",
                         "pfc_enable": "2,3,4,6",
-                        "pfcwd_sw_enable" : "2,3,4,6"
+                        "pfcwd_sw_enable" : "2,3,4,6",
+                        "scheduler" : "port_scheduler"
                     }
                 ]
             }
@@ -750,7 +769,36 @@
             }
         }
     },
-   
+
+    "PORT_QOS_MAP_APPLY_NON_EXISTS_SCHEDULER": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet0",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet0",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-port-qos-map:sonic-port-qos-map": {
+            "sonic-port-qos-map:PORT_QOS_MAP": {
+                "PORT_QOS_MAP_LIST": [
+                    {
+                        "ifname": "Ethernet0",
+                        "scheduler": "scheduler1"
+                    }
+                ]
+            }
+        }
+    },
+
      "PORT_QOS_MAP_APPLY_NON_EXISTS_PORT": {
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -34,6 +34,10 @@ module sonic-port-qos-map {
         prefix dot1ptm;
     }
 
+    import sonic-scheduler {
+        prefix sch;
+    }
+
     organization
         "SONiC";
 
@@ -116,6 +120,13 @@ module sonic-port-qos-map {
                     type leafref {
                         path "/dot1ptm:sonic-dot1p-tc-map/dot1ptm:DOT1P_TO_TC_MAP/dot1ptm:DOT1P_TO_TC_MAP_LIST/dot1ptm:name";
                     }
+                }
+
+                leaf scheduler {
+                    type leafref {
+                        path "/sch:sonic-scheduler/sch:SCHEDULER/sch:SCHEDULER_LIST/sch:name"; //Reference to SCHEDULER table
+                    }
+                    description "Scheduler for port.";
                 }
             }
         }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Backport to 202211

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

