### PR TITLE
Fix NULL pointer access in systemd-sonic-generator

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.c
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.c
@@ -269,7 +269,7 @@ int get_install_targets(char* unit_file, char* targets[]) {
     char* token;
     char* line = NULL;
     bool first;
-    char* target_suffix;
+    char* target_suffix = NULL;
     char *instance_name;
     char *dot_ptr;
 
@@ -308,7 +308,7 @@ int get_install_targets(char* unit_file, char* targets[]) {
                     target_suffix = ".wants";
                 }
             }
-            else {
+            else if (NULL != target_suffix) {
                 found_targets = get_install_targets_from_line(token, target_suffix, targets, num_targets);
                 num_targets += found_targets;
             }

--- a/src/systemd-sonic-generator/tests/testfiles/multi_inst_a.service
+++ b/src/systemd-sonic-generator/tests/testfiles/multi_inst_a.service
@@ -6,4 +6,5 @@ StartLimitBurst=3
 User=root
 ExecStop=/usr/bin/test.sh stop
 [Install]
+Alias=alias
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix NULL pointer access when there is no `WantedBy` or `RequiredBy` in the first line.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Manual and unit test.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

