### PR TITLE
[202311][Mellanox] Support read/write more than 1 page in a single platform API call (#18881)

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -355,23 +355,40 @@ class SFP(NvidiaSFPCommon):
         Returns:
             bytearray: the content of EEPROM
         """
-        _, page, page_offset = self._get_page_and_page_offset(offset)
-        if not page:
-            return None
+        result = None
+        while num_bytes > 0:
+            _, page, page_offset = self._get_page_and_page_offset(offset)
+            if not page:
+                return None
 
-        try:
-            with open(page, mode='rb', buffering=0) as f:
-                f.seek(page_offset)
-                content = f.read(num_bytes)
-                if ctypes.get_errno() != 0:
-                    raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
-        except (OSError, IOError) as e:
-            if log_on_error:
-                logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, \
-                    size={num_bytes}, offset={offset}, error = {e}')
-            return None
+            try:
+                with open(page, mode='rb', buffering=0) as f:
+                    f.seek(page_offset)
+                    content = f.read(num_bytes)
+                    if not result:
+                        result = content
+                    else:
+                        result += content
+                    read_length = len(content)
+                    num_bytes -= read_length
+                    if num_bytes > 0:
+                        page_size = f.seek(0, os.SEEK_END)
+                        if page_offset + read_length == page_size:
+                            offset += read_length
+                        else:
+                            # Indicate read finished
+                            num_bytes = 0
+                    if ctypes.get_errno() != 0:
+                        raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+                    logger.log_debug(f'read EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, '\
+                        f'size={read_length}, data={content}')
+            except (OSError, IOError) as e:
+                if log_on_error:
+                    logger.log_warning(f'Failed to read sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, '\
+                        f'size={num_bytes}, offset={offset}, error = {e}')
+                return None
 
-        return bytearray(content)
+        return bytearray(result)
 
     # write eeprom specfic bytes beginning from offset with size as num_bytes
     def write_eeprom(self, offset, num_bytes, write_buffer):
@@ -387,27 +404,38 @@ class SFP(NvidiaSFPCommon):
             logger.log_error("Error mismatch between buffer length and number of bytes to be written")
             return False
 
-        page_num, page, page_offset = self._get_page_and_page_offset(offset)
-        if not page:
-            return False
+        while num_bytes > 0:
+            page_num, page, page_offset = self._get_page_and_page_offset(offset)
+            if not page:
+                return False
 
-        try:
-            if self._is_write_protected(page_num, page_offset, num_bytes):
-                # write limited eeprom is not supported
-                raise IOError('write limited bytes')
+            try:
+                if self._is_write_protected(page_num, page_offset, num_bytes):
+                    # write limited eeprom is not supported
+                    raise IOError('write limited bytes')
+                with open(page, mode='r+b', buffering=0) as f:
+                    f.seek(page_offset)
+                    ret = f.write(write_buffer[0:num_bytes])
+                    written_buffer = write_buffer[0:ret]
+                    if ret != num_bytes:
+                        page_size = f.seek(0, os.SEEK_END)
+                        if page_offset + ret == page_size:
+                            # Move to next page
+                            write_buffer = write_buffer[ret:num_bytes]
+                            offset += ret
+                        else:
+                            raise IOError(f'write return code = {ret}')
+                    num_bytes -= ret
+                    if ctypes.get_errno() != 0:
+                        raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
+                    logger.log_debug(f'write EEPROM sfp={self.sdk_index}, page={page}, page_offset={page_offset}, '\
+                        f'size={ret}, left={num_bytes}, data={written_buffer}')
+            except (OSError, IOError) as e:
+                data = ''.join('{:02x}'.format(x) for x in write_buffer)
+                logger.log_error(f'Failed to write EEPROM data sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, size={num_bytes}, '\
+                    f'offset={offset}, data = {data}, error = {e}')
+                return False
 
-            with open(page, mode='r+b', buffering=0) as f:
-                f.seek(page_offset)
-                ret = f.write(write_buffer[0:num_bytes])
-                if ret != num_bytes:
-                    raise IOError(f'write return code = {ret}')
-                if ctypes.get_errno() != 0:
-                    raise IOError(f'errno = {os.strerror(ctypes.get_errno())}')
-        except (OSError, IOError) as e:
-            data = ''.join('{:02x}'.format(x) for x in write_buffer)
-            logger.log_error(f'Failed to write EEPROM data sfp={self.sdk_index} EEPROM page={page}, page_offset={page_offset}, size={num_bytes}, \
-                offset={offset}, data = {data}, error = {e}')
-            return False
         return True
 
     @classmethod

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -131,6 +131,17 @@ class TestSfp:
             handle.write.side_effect = OSError('')
             assert not sfp.write_eeprom(0, 1, bytearray([1]))
 
+        mo = mock.mock_open()
+        print('after mock open')
+        with mock.patch('sonic_platform.sfp.open', mo):
+            handle = mo()
+            handle.write.side_effect = [128, 128, 64]
+            handle.seek.side_effect = [0, 128, 0, 128, 0]
+            bytes_to_write = bytearray([0]*128 + [1]*128 + [2]*64)
+            assert sfp.write_eeprom(0, 320, bytes_to_write)
+            expected_calls = [mock.call(bytes_to_write), mock.call(bytes_to_write[128:]), mock.call(bytes_to_write[256:])]
+            handle.write.assert_has_calls(expected_calls)
+
     @mock.patch('sonic_platform.sfp.SFP._get_page_and_page_offset')
     def test_sfp_read_eeprom(self, mock_get_page):
         sfp = SFP(0)
@@ -151,6 +162,13 @@ class TestSfp:
 
             handle.read.side_effect = OSError('')
             assert sfp.read_eeprom(0, 1) is None
+
+        mo = mock.mock_open()
+        with mock.patch('sonic_platform.sfp.open', mo):
+            handle = mo()
+            handle.read.side_effect = [b'\x00'*128, b'\x01'*128, b'\x02'*64]
+            handle.seek.side_effect = [0, 128, 0, 128, 0]
+            assert sfp.read_eeprom(0, 320) == bytearray([0]*128 + [1]*128 + [2]*64)
 
     @mock.patch('sonic_platform.sfp.SFP._fetch_port_status')
     def test_is_port_admin_status_up(self, mock_port_status):

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION


- Why I did it

Back port PR 18881 to 202311
Support read/write more than 1 page in a single platform API call.

- How to verify it

Manual and mock test

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

