### PR TITLE
[Yang model] Support empty string in pfc_enable and pfc_wd_enable fields in PORT_QOS_MAP table

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qosmaps.json
@@ -111,6 +111,14 @@
         "eStrKey": "Pattern"
     },
 
+    "PORT_QOS_MAP_APPLY_EMPTY_PFC": {
+        "desc": "Configure port pfc enable with empty string to disable PFC on all queues."
+    },
+
+    "PORT_QOS_MAP_APPLY_EMPTY_PFCWD": {
+        "desc": "Configure port pfcwd_sw_enable with empty string to disable watchdog on all queues."
+    },
+
     "TC_TO_DSCP_MAP_CRETAE": {
         "desc": "Configure a Traffic class to DSCP map."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qosmaps.json
@@ -881,6 +881,64 @@
         }
     },
 
+    "PORT_QOS_MAP_APPLY_EMPTY_PFC": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-port-qos-map:sonic-port-qos-map": {
+            "sonic-port-qos-map:PORT_QOS_MAP": {
+                "PORT_QOS_MAP_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "pfc_enable": ""
+                    }
+                ]
+            }
+        }
+    },
+
+    "PORT_QOS_MAP_APPLY_EMPTY_PFCWD": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-port-qos-map:sonic-port-qos-map": {
+            "sonic-port-qos-map:PORT_QOS_MAP": {
+                "PORT_QOS_MAP_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "pfcwd_sw_enable": ""
+                    }
+                ]
+            }
+        }
+    },
+
     "TC_TO_DSCP_MAP_CRETAE": {
         "sonic-tc-dscp-map:sonic-tc-dscp-map": {
             "sonic-tc-dscp-map:TC_TO_DSCP_MAP": {

--- a/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port-qos-map.yang
@@ -91,16 +91,18 @@ module sonic-port-qos-map {
 
                 leaf pfc_enable {
                     type string {
-                        pattern "[0-7](,[0-7])*";
+                        pattern "([0-7](,[0-7])*)?";
                     }
+                    description
+                        "Specify the queue(s) on which PFC is enabled. Empty string is allowed to disable PFC on all queues.";
                 }
 
                 leaf pfcwd_sw_enable {
                     type string {
-                        pattern "[0-7](,[0-7])*";
+                        pattern "([0-7](,[0-7])*)?";
                     }
                     description
-                        "Specify the queue(s) on which software pfc watchdog are enabled.";
+                        "Specify the queue(s) on which software pfc watchdog are enabled. Empty string is allowed to disable watchdog on all queues.";
                 }
 
                 leaf pfc_to_queue_map {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Support empty string in pfc_enable and pfc_wd_enable fields in PORT_QOS_MAP table to represent "disable PFC ".

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Unit/manul test

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

