### PR TITLE
Fix issue that the egress zero lossy profile is not defined in dynamic mode on SN5600/SN5610/SN5640

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
@@ -148,6 +148,7 @@
 
 {%- macro generate_queue_buffers(port_names_active, port_names_inactive) %}
     "BUFFER_QUEUE": {
+{% if dynamic_mode is not defined %}
 {% for port in port_names_active.split(',') %}
         "{{ port }}|0-3": {
             "profile" : "q_lossy_profile"
@@ -170,13 +171,37 @@
 
 {% endfor %}
 {% if port_names_inactive|length > 0 %}
+{% if dynamic_mode is defined %}
+{% if port_names_active.split(',')|length > 0 %},{% endif %}
 {% for port in port_names_inactive.split(',') %}
-       {%- if loop.first -%},{%- endif -%}
-        "{{ port }}|1-6": {
+        "{{ port }}|0-3": {
+            "profile" : "q_lossy_profile"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|4": {
+            "profile" : "q_lossy_infinity_profile"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|5": {
+            "profile" : "q_lossy_minus_3_profile"
+        },
+{% endfor %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|6": {
+            "profile" : "q_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% else %}
+{% if port_names_active.split(',')|length > 0 %},{% endif %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-6": {
             "profile" : "egress_lossy_zero_profile"
         }{% if not loop.last %},{% endif %}
-
 {% endfor %}
+{% endif %}
+{% endif %}
 {% endif %}
     }
 {%- endmacro %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix issue that the egress zero lossy profile is not defined in dynamic mode on SN5600/SN5610/SN5640

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

