### PR TITLE
Increate RTNL socket size to 8M by default for all teamd sockets

### DIFF
--- a/src/libteam/patch/0005-Increase-default-buffer-size-from-98304-to-2097152.patch
+++ b/src/libteam/patch/0005-Increase-default-buffer-size-from-98304-to-2097152.patch
@@ -1,7 +1,7 @@
 From fcb9932bdb9212e9b18302de4ffb4d64003e93ab Mon Sep 17 00:00:00 2001
 From: Pavel Shirshov <pavelsh@microsoft.com>
 Date: Tue, 3 Mar 2020 12:55:50 -0800
-Subject: [PATCH] Increase default buffer size from 98304 to 2097152
+Subject: [PATCH] Increase default buffer size from 98304 to 8MB
 
 ---
  libteam/libteam.c | 4 ++--
@@ -16,10 +16,10 @@ index 9c9c93a..2cc80ca 100644
  
  /* libnl uses default 32k socket receive buffer size,
 - * which can get too small. Use 192k for all sockets.
-+ * which can get too small. Use 2048k for all sockets.
++ * which can get too small. Use 8MB for all sockets (LAG scale).
   */
 -#define NETLINK_RCVBUF 196608
-+#define NETLINK_RCVBUF 2097152
++#define NETLINK_RCVBUF 8388608
  
  /**
   * @param th		libteam library context


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Increate RTNL socket size to 8M by default for all teamd sockets
On SN6600 we support much more LAGs which requires larger RTNL socket size.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

