### PR TITLE
Support override SONIC_OVERRIDE_BUILD_VARS when building from the slave docker

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -345,6 +345,12 @@ ifdef SONIC_BUILD_QUIETER
 	DOCKER_RUN += -e "SONIC_BUILD_QUIETER=$(SONIC_BUILD_QUIETER)"
 endif
 
+# Pass SONIC_OVERRIDE_BUILD_VARS into the container so that make -f slave.mk run inside
+# the container (e.g. after KEEP_SLAVE_ON=yes) sees the same overrides.
+ifneq ($(SONIC_OVERRIDE_BUILD_VARS),)
+	DOCKER_RUN += -e "SONIC_OVERRIDE_BUILD_VARS=$(SONIC_OVERRIDE_BUILD_VARS)"
+endif
+
 # Mount the Signing key and Certificate in the slave container
 ifneq ($(SECURE_UPGRADE_DEV_SIGNING_KEY),)
     DOCKER_RUN += -v $(SECURE_UPGRADE_DEV_SIGNING_KEY):$(SECURE_UPGRADE_DEV_SIGNING_KEY):ro

--- a/slave.mk
+++ b/slave.mk
@@ -104,6 +104,30 @@ export FILES_PATH
 export PROJECT_ROOT
 export PTF_ENV_PY_VER
 
+# When using make -f slave.mk, the main Makefile is never read, so SONIC_OVERRIDE_BUILD_VARS
+# is not applied as make command-line arguments (unlike the docker path which passes them via
+# SONIC_BUILD_INSTRUCTION in Makefile.work). Re-invoke make with the override vars as
+# arguments so that platform rules (e.g. sdk.mk, mlnx-sai.mk) see MLNX_*, SONIC_* etc.
+# When in re-invoke mode we only define these two rules and skip including the rest of the
+# makefile so the target has no other prerequisites (avoids jobserver deadlock with inner make).
+ifneq ($(SONIC_OVERRIDE_BUILD_VARS),)
+ifneq ($(SONIC_OVERRIDE_APPLIED),1)
+_apply_sonic_overrides:
+	@( unset MAKEFLAGS MFLAGS; $(MAKE) -j$(SONIC_BUILD_JOBS) -f $(firstword $(MAKEFILE_LIST)) SONIC_OVERRIDE_APPLIED=1 $(SONIC_OVERRIDE_BUILD_VARS) $(MAKECMDGOALS) )
+%:: _apply_sonic_overrides
+	@:
+.PHONY: _apply_sonic_overrides
+_slave_skip_includes := 1
+endif
+endif
+export SONIC_OVERRIDE_BUILD_VARS
+
+# When in re-invoke-only mode we must not include deb/docker rules (no other prerequisites).
+ifeq ($(_slave_skip_includes),1)
+###############################################################################
+## Re-invoke only: no further includes
+###############################################################################
+else
 ###############################################################################
 ## Utility rules
 ## Define configuration, help etc.
@@ -1833,3 +1857,6 @@ jessie : $$(addprefix $(TARGET_PATH)/,$$(JESSIE_DOCKER_IMAGES)) \
 ## To build some commonly used libs. Some submodules depend on these libs.
 ## It is used in component pipelines. For example: swss needs libnl, libyang
 lib-packages: $(addprefix $(DEBS_PATH)/,$(LIBNL3) $(LIBYANG) $(LIBYANG3) $(PROTOBUF) $(LIB_SONIC_DASH_API))
+
+endif
+## end of ifeq ($(_slave_skip_includes),1) from top of file


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

